### PR TITLE
Limit witness/relayer compose to iotex and bsc; bump configs submodule

### DIFF
--- a/witness-service/docker-compose-relayer.yml
+++ b/witness-service/docker-compose-relayer.yml
@@ -27,20 +27,20 @@ services:
     environment:
       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
 
-  ethereum-payload-relayer:
-    container_name: ethereum-payload-relayer
-    image: relayer:latest
-    restart: on-failure
-    ports:
-      - 7200:7200
-      - 8200:8200
-    volumes:
-      - $IOTEX_RELAYER/etc/relayer-config-ethereum-payload.yaml:/etc/iotube-relayer/relayer-config-ethereum-payload.yaml:ro
-    links:
-      - database
-    command: relayer -config=/etc/iotube-relayer/relayer-config-ethereum-payload.yaml
-    environment:
-      RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+#   ethereum-payload-relayer:
+#     container_name: ethereum-payload-relayer
+#     image: relayer:latest
+#     restart: on-failure
+#     ports:
+#       - 7200:7200
+#       - 8200:8200
+#     volumes:
+#       - $IOTEX_RELAYER/etc/relayer-config-ethereum-payload.yaml:/etc/iotube-relayer/relayer-config-ethereum-payload.yaml:ro
+#     links:
+#       - database
+#     command: relayer -config=/etc/iotube-relayer/relayer-config-ethereum-payload.yaml
+#     environment:
+#       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
 
   bsc-payload-relayer:
     container_name: bsc-payload-relayer
@@ -57,62 +57,62 @@ services:
     environment:
       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
 
-  matic-payload-relayer:
-    container_name: matic-payload-relayer
-    image: relayer:latest
-    restart: on-failure
-    ports:
-      - 7204:7204
-      - 8204:8204
-    volumes:
-      - $IOTEX_RELAYER/etc/relayer-config-matic-payload.yaml:/etc/iotube-relayer/relayer-config-matic-payload.yaml:ro
-    links:
-      - database
-    command: relayer -config=/etc/iotube-relayer/relayer-config-matic-payload.yaml
-    environment:
-      RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+#   matic-payload-relayer:
+#     container_name: matic-payload-relayer
+#     image: relayer:latest
+#     restart: on-failure
+#     ports:
+#       - 7204:7204
+#       - 8204:8204
+#     volumes:
+#       - $IOTEX_RELAYER/etc/relayer-config-matic-payload.yaml:/etc/iotube-relayer/relayer-config-matic-payload.yaml:ro
+#     links:
+#       - database
+#     command: relayer -config=/etc/iotube-relayer/relayer-config-matic-payload.yaml
+#     environment:
+#       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
 
-  iotex-solana-relayer:
-    container_name: iotex-solana-relayer
-    image: relayer:latest
-    restart: on-failure
-    ports:
-      - 7008:7008
-      - 8008:8008
-    volumes:
-      - $IOTEX_RELAYER/etc/relayer-config-iotex-solana.yaml:/etc/iotube-relayer/relayer-config-iotex-solana.yaml:ro
-    links:
-      - database
-    command: relayer -config=/etc/iotube-relayer/relayer-config-iotex-solana.yaml
-    environment:
-      RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+#   iotex-solana-relayer:
+#     container_name: iotex-solana-relayer
+#     image: relayer:latest
+#     restart: on-failure
+#     ports:
+#       - 7008:7008
+#       - 8008:8008
+#     volumes:
+#       - $IOTEX_RELAYER/etc/relayer-config-iotex-solana.yaml:/etc/iotube-relayer/relayer-config-iotex-solana.yaml:ro
+#     links:
+#       - database
+#     command: relayer -config=/etc/iotube-relayer/relayer-config-iotex-solana.yaml
+#     environment:
+#       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
 
-  solana-relayer:
-    container_name: solana-relayer
-    image: relayer:latest
-    restart: on-failure
-    ports:
-      - 7007:7007
-      - 8007:8007
-    volumes:
-      - $IOTEX_RELAYER/etc/relayer-config-solana.yaml:/etc/iotube-relayer/relayer-config-solana.yaml:ro
-    links:
-      - database
-    command: relayer -config=/etc/iotube-relayer/relayer-config-solana.yaml
-    environment:
-      RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+#   solana-relayer:
+#     container_name: solana-relayer
+#     image: relayer:latest
+#     restart: on-failure
+#     ports:
+#       - 7007:7007
+#       - 8007:8007
+#     volumes:
+#       - $IOTEX_RELAYER/etc/relayer-config-solana.yaml:/etc/iotube-relayer/relayer-config-solana.yaml:ro
+#     links:
+#       - database
+#     command: relayer -config=/etc/iotube-relayer/relayer-config-solana.yaml
+#     environment:
+#       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
 
-  cron:
-    image: schnitzler/mysqldump
-    restart: always
-    volumes:
-      - $IOTEX_RELAYER/etc/crontab:/var/spool/cron/crontabs/root
-      - $IOTEX_RELAYER/etc/backup:/usr/local/bin/backup
-    volumes_from:
-      - backup
-    command: ["-l", "8", "-d", "8"]
-    environment:
-      MYSQL_HOST: database
-      MYSQL_USER: root
-      MYSQL_PASSWORD: ${DB_ROOT_PASSWORD}
-      MYSQL_DATABASE: relayer
+#   cron:
+#     image: schnitzler/mysqldump
+#     restart: always
+#     volumes:
+#       - $IOTEX_RELAYER/etc/crontab:/var/spool/cron/crontabs/root
+#       - $IOTEX_RELAYER/etc/backup:/usr/local/bin/backup
+#     volumes_from:
+#       - backup
+#     command: ["-l", "8", "-d", "8"]
+#     environment:
+#       MYSQL_HOST: database
+#       MYSQL_USER: root
+#       MYSQL_PASSWORD: ${DB_ROOT_PASSWORD}
+#       MYSQL_DATABASE: relayer

--- a/witness-service/docker-compose-witness.yml
+++ b/witness-service/docker-compose-witness.yml
@@ -25,18 +25,18 @@ services:
       WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
       RELAYER_URL: ${RELAYER_URL}
 
-  ethereum-payload-witness:
-    container_name: ethereum-payload-witness
-    image: witness:latest
-    restart: on-failure
-    volumes:
-      - $IOTEX_WITNESS/etc/witness-config-ethereum-payload.yaml:/etc/iotube-witness/witness-config-ethereum-payload.yaml:ro
-      - $IOTEX_WITNESS/etc/witness-config-ethereum.secret.yaml:/etc/iotube-witness/witness-config-ethereum.secret.yaml:ro
-    network_mode: host
-    command: witness -config=/etc/iotube-witness/witness-config-ethereum-payload.yaml -secret=/etc/iotube-witness/witness-config-ethereum.secret.yaml
-    environment:
-      WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
-      RELAYER_URL: ${RELAYER_URL}
+#   ethereum-payload-witness:
+#     container_name: ethereum-payload-witness
+#     image: witness:latest
+#     restart: on-failure
+#     volumes:
+#       - $IOTEX_WITNESS/etc/witness-config-ethereum-payload.yaml:/etc/iotube-witness/witness-config-ethereum-payload.yaml:ro
+#       - $IOTEX_WITNESS/etc/witness-config-ethereum.secret.yaml:/etc/iotube-witness/witness-config-ethereum.secret.yaml:ro
+#     network_mode: host
+#     command: witness -config=/etc/iotube-witness/witness-config-ethereum-payload.yaml -secret=/etc/iotube-witness/witness-config-ethereum.secret.yaml
+#     environment:
+#       WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
+#       RELAYER_URL: ${RELAYER_URL}
 
   bsc-payload-witness:
     container_name: bsc-payload-witness
@@ -51,61 +51,61 @@ services:
       WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
       RELAYER_URL: ${RELAYER_URL}
 
-  matic-payload-witness:
-    container_name: matic-payload-witness
-    image: witness:latest
-    restart: on-failure
-    volumes:
-      - $IOTEX_WITNESS/etc/witness-config-matic-payload.yaml:/etc/iotube-witness/witness-config-matic-payload.yaml:ro
-      - $IOTEX_WITNESS/etc/witness-config-matic.secret.yaml:/etc/iotube-witness/witness-config-matic.secret.yaml:ro
-    network_mode: host
-    command: witness -config=/etc/iotube-witness/witness-config-matic-payload.yaml -secret=/etc/iotube-witness/witness-config-matic.secret.yaml
-    environment:
-      WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
-      RELAYER_URL: ${RELAYER_URL}
+#   matic-payload-witness:
+#     container_name: matic-payload-witness
+#     image: witness:latest
+#     restart: on-failure
+#     volumes:
+#       - $IOTEX_WITNESS/etc/witness-config-matic-payload.yaml:/etc/iotube-witness/witness-config-matic-payload.yaml:ro
+#       - $IOTEX_WITNESS/etc/witness-config-matic.secret.yaml:/etc/iotube-witness/witness-config-matic.secret.yaml:ro
+#     network_mode: host
+#     command: witness -config=/etc/iotube-witness/witness-config-matic-payload.yaml -secret=/etc/iotube-witness/witness-config-matic.secret.yaml
+#     environment:
+#       WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
+#       RELAYER_URL: ${RELAYER_URL}
 
-  solana-witness:
-    container_name: solana-witness
-    image: witness:latest
-    restart: on-failure
-    volumes:
-      - $IOTEX_WITNESS/etc/witness-config-solana.yaml:/etc/iotube-witness/witness-config-solana.yaml:ro
-      - $IOTEX_WITNESS/etc/witness-config-solana.secret.yaml:/etc/iotube-witness/witness-config-solana.secret.yaml:ro
-    network_mode: host
-    command: witness -config=/etc/iotube-witness/witness-config-solana.yaml -secret=/etc/iotube-witness/witness-config-solana.secret.yaml
-    environment:
-      WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
-      RELAYER_URL: ${RELAYER_URL}
+#   solana-witness:
+#     container_name: solana-witness
+#     image: witness:latest
+#     restart: on-failure
+#     volumes:
+#       - $IOTEX_WITNESS/etc/witness-config-solana.yaml:/etc/iotube-witness/witness-config-solana.yaml:ro
+#       - $IOTEX_WITNESS/etc/witness-config-solana.secret.yaml:/etc/iotube-witness/witness-config-solana.secret.yaml:ro
+#     network_mode: host
+#     command: witness -config=/etc/iotube-witness/witness-config-solana.yaml -secret=/etc/iotube-witness/witness-config-solana.secret.yaml
+#     environment:
+#       WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
+#       RELAYER_URL: ${RELAYER_URL}
   
-  iotex-solana-witness:
-    container_name: iotex-solana-witness
-    image: witness:latest
-    restart: on-failure
-    volumes:
-      - $IOTEX_WITNESS/etc/witness-config-iotex-solana.yaml:/etc/iotube-witness/witness-config-iotex-solana.yaml:ro
-      - $IOTEX_WITNESS/etc/witness-config-iotex-solana.secret.yaml:/etc/iotube-witness/witness-config-iotex-solana.secret.yaml:ro
-    network_mode: host
-    command: witness -config=/etc/iotube-witness/witness-config-iotex-solana.yaml -secret=/etc/iotube-witness/witness-config-iotex-solana.secret.yaml
-    environment:
-      WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
-      RELAYER_URL: ${RELAYER_URL}
+#   iotex-solana-witness:
+#     container_name: iotex-solana-witness
+#     image: witness:latest
+#     restart: on-failure
+#     volumes:
+#       - $IOTEX_WITNESS/etc/witness-config-iotex-solana.yaml:/etc/iotube-witness/witness-config-iotex-solana.yaml:ro
+#       - $IOTEX_WITNESS/etc/witness-config-iotex-solana.secret.yaml:/etc/iotube-witness/witness-config-iotex-solana.secret.yaml:ro
+#     network_mode: host
+#     command: witness -config=/etc/iotube-witness/witness-config-iotex-solana.yaml -secret=/etc/iotube-witness/witness-config-iotex-solana.secret.yaml
+#     environment:
+#       WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
+#       RELAYER_URL: ${RELAYER_URL}
 
-  cron:
-    image: schnitzler/mysqldump
-    restart: always
-    volumes:
-      - $IOTEX_WITNESS/etc/crontab:/var/spool/cron/crontabs/root
-      - $IOTEX_WITNESS/etc/backup:/usr/local/bin/backup
-    volumes_from:
-      - backup
-    command: ["-l", "8", "-d", "8"]
-    environment:
-      MYSQL_HOST: database
-      MYSQL_USER: root
-      MYSQL_PASSWORD: ${DB_ROOT_PASSWORD}
-      MYSQL_DATABASE: witness
+#   cron:
+#     image: schnitzler/mysqldump
+#     restart: always
+#     volumes:
+#       - $IOTEX_WITNESS/etc/crontab:/var/spool/cron/crontabs/root
+#       - $IOTEX_WITNESS/etc/backup:/usr/local/bin/backup
+#     volumes_from:
+#       - backup
+#     command: ["-l", "8", "-d", "8"]
+#     environment:
+#       MYSQL_HOST: database
+#       MYSQL_USER: root
+#       MYSQL_PASSWORD: ${DB_ROOT_PASSWORD}
+#       MYSQL_DATABASE: witness
 
-  backup:
-    image: busybox
-    volumes:
-      - $IOTEX_WITNESS/data/backup:/backup
+#   backup:
+#     image: busybox
+#     volumes:
+#       - $IOTEX_WITNESS/data/backup:/backup


### PR DESCRIPTION
## Summary
- Comment out ethereum, matic, solana, and iotex-solana services in `witness-service/docker-compose-witness.yml` and `witness-service/docker-compose-relayer.yml`, so `docker compose up` brings up only the iotex and bsc witness/relayer pair (+ database).
- Comment out the `cron` (and witness `backup`) services in the same files. They are not needed for the iotex-bsc-only deployment, and the relayer compose `cron` referenced an undefined `backup` service which made compose v2 reject the whole file.
- Bump the `witness-service/configs` submodule pointer to pick up the XPIN-only iotex-bsc bridge trim — see https://github.com/iotubeproject/iotube-configs/pull/8.

All disabled services are commented (not deleted) so they can be re-enabled by removing the `#` prefixes.

## Test plan
- [ ] `docker compose -f witness-service/docker-compose-relayer.yml config` parses without errors.
- [ ] `docker compose -f witness-service/docker-compose-witness.yml config` parses without errors.
- [ ] Locally: `docker compose up -d database iotex-payload-relayer bsc-payload-relayer` brings up only those three containers, no others.
- [ ] Same for witnesses once the configs PR is merged and the submodule pointer is updated to a merged commit.

## Notes
- This branch points at an unmerged commit of `iotube-configs:config-update`. Once that PR merges, the submodule pointer here should be updated to the merged commit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)