### PR TITLE
witness: pre-sign approval guard with USD-based caps

### DIFF
--- a/witness-service/README.md
+++ b/witness-service/README.md
@@ -9,3 +9,8 @@
 3. copy .env.template `~/iotex-witness/etc/.env`, and set values
 4. set `clientURL` in `witness-config-ethereum.secret.yaml`
 5. run `./start_witness.sh` to build and start running services.
+
+## Operations
+
+- [Missing / deleted source transaction runbook](docs/missing-transaction-runbook.md) — what to
+  do when a witness can't fetch a stale block's source data (find, sign, submit, mute).

--- a/witness-service/cmd/witness/main.go
+++ b/witness-service/cmd/witness/main.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -117,8 +118,11 @@ type TokenPair struct {
 	TokenProgramID string   `json:"tokenProgramID,omitempty" yaml:"tokenProgramID,omitempty"`
 	Whitelist      []string `json:"whitelist" yaml:"whitelist"`
 	// CoinGeckoID is the CoinGecko coin id (e.g. "weth", "wrapped-bitcoin")
-	// used to fetch this token's USD price. Required when the parent cashier
-	// has a USD windowValueLimit or singleTxValueLimit configured.
+	// used to fetch this token's USD price. Optional: when omitted, the
+	// witness resolves it at startup via CoinGecko's contract-address lookup
+	// (/coins/{platform}/contract/{token1}). Set it explicitly only to
+	// override the auto-resolved id — useful for bridged tokens CoinGecko
+	// doesn't index under the bridged contract.
 	CoinGeckoID string `json:"coingeckoID" yaml:"coingeckoID"`
 	// Decimals is the number of decimal places of the value returned by
 	// AbstractTransfer.Amount() — i.e. after any DecimalRound adjustment.
@@ -271,10 +275,9 @@ func main() {
 	}
 
 	approvalGuards := make(map[string]*witness.ApprovalGuard)
-	priceCache, priceRunner := startPriceFeed(cfg)
-	if priceRunner != nil {
-		defer priceRunner.Close()
-	}
+	cgClient, priceCache := newPriceFeed(cfg)
+	resolver := newCoingeckoResolver(cgClient, cfg.Chain)
+	var allTokenMetas []witness.TokenMeta
 
 	storeFactory := db.NewSQLStoreFactory()
 	cashiers := make([]witness.TokenCashier, 0, len(cfg.Cashiers))
@@ -456,12 +459,13 @@ func main() {
 			var ethTokenMetas []witness.TokenMeta
 			if cc.ToSolana {
 				// For ETH→SOL cashiers token1 is still an EVM address; same path.
-				ethTokenMetas = tokenMetasForEthereum(cc.TokenPairs)
+				ethTokenMetas = tokenMetasForEthereum(cc.TokenPairs, resolver)
 			} else if cfg.Chain == "iotex" || cfg.Chain == "iotex-e" || cfg.Chain == "iotex-testnet" {
-				ethTokenMetas = tokenMetasForIotex(cc.TokenPairs)
+				ethTokenMetas = tokenMetasForIotex(cc.TokenPairs, resolver)
 			} else {
-				ethTokenMetas = tokenMetasForEthereum(cc.TokenPairs)
+				ethTokenMetas = tokenMetasForEthereum(cc.TokenPairs, resolver)
 			}
+			allTokenMetas = append(allTokenMetas, ethTokenMetas...)
 			guard := buildApprovalGuard(cfg.Approval, cashierKey, cc.WindowValueLimit, cc.SingleTxValueLimit, ethTokenMetas, priceCache, ethRecorder)
 			if guard != nil {
 				approvalGuards[cashierKey] = guard
@@ -500,6 +504,10 @@ func main() {
 		if err := witness.NewApprovalServer(cfg.Approval.ServerListenAddr, cfg.Approval.LarkSigningSecret, approvalGuards).Start(); err != nil {
 			log.Fatalf("failed to start approval server: %v\n", err)
 		}
+	}
+
+	if priceRunner := startPriceFeedRunner(cfg, cgClient, priceCache, collectCoinGeckoIDsFromMetas(allTokenMetas)); priceRunner != nil {
+		defer priceRunner.Close()
 	}
 
 	service, err := witness.NewService(
@@ -573,10 +581,16 @@ func buildApprovalGuard(
 		log.Fatalf("approval guard for %s configured with USD limit but no price source", cashierKey)
 	}
 	for _, tk := range tokens {
-		if tk.CoinGeckoID == "" || tk.Decimals < 0 {
+		if tk.CoinGeckoID == "" {
 			log.Fatalf(
-				"approval guard for %s: token %s missing coingeckoID or has negative decimals (have id=%q decimals=%d)",
-				cashierKey, tk.Token, tk.CoinGeckoID, tk.Decimals,
+				"approval guard for %s: could not resolve CoinGecko id for token %s (set coingeckoID in config to override)",
+				cashierKey, tk.Token,
+			)
+		}
+		if tk.Decimals < 0 {
+			log.Fatalf(
+				"approval guard for %s: token %s has negative decimals (%d)",
+				cashierKey, tk.Token, tk.Decimals,
 			)
 		}
 	}
@@ -610,29 +624,38 @@ func parseUsdLimit(s string) *big.Float {
 	return v
 }
 
-// startPriceFeed builds the shared *util.PriceCache and a periodic refresh
-// runner. When priceFeed.enabled is false (or no cashier needs prices) returns
-// (nil, nil) — the witness behaves exactly as it did before USD limits existed.
-// The runner is owned by the caller and must be Close()'d before exit.
-func startPriceFeed(cfg Configuration) (*util.PriceCache, dispatcher.Runner) {
+// newPriceFeed creates the CoinGecko client and the in-process PriceCache.
+// Returns (nil, nil) when priceFeed.enabled is false — the witness behaves
+// exactly as it did before USD limits existed. Does NOT start the periodic
+// refresh runner; that happens later via startPriceFeedRunner after all
+// CoinGecko ids (explicit + auto-resolved) are known.
+func newPriceFeed(cfg Configuration) (*util.CoinGeckoClient, *util.PriceCache) {
 	if !cfg.PriceFeed.Enabled {
-		return nil, nil
-	}
-	ids := collectCoinGeckoIDs(cfg)
-	if len(ids) == 0 {
-		log.Println("priceFeed.enabled=true but no token pair declares coingeckoID; skipping refresh loop")
 		return nil, nil
 	}
 	maxAge := cfg.PriceFeed.MaxPriceAge
 	if maxAge == 0 {
 		maxAge = 10 * time.Minute
 	}
+	client := util.NewCoinGeckoClient(cfg.PriceFeed.BaseURL, cfg.PriceFeed.APIKey, cfg.PriceFeed.RequestTimeout)
+	return client, util.NewPriceCache(maxAge)
+}
+
+// startPriceFeedRunner starts the periodic price refresh against the given
+// CoinGecko ids. Caller must defer runner.Close(). Returns nil when the
+// price feed is disabled or no ids need fetching.
+func startPriceFeedRunner(cfg Configuration, client *util.CoinGeckoClient, cache *util.PriceCache, ids []string) dispatcher.Runner {
+	if client == nil || cache == nil {
+		return nil
+	}
+	if len(ids) == 0 {
+		log.Println("priceFeed.enabled=true but no coingecko ids resolved; skipping refresh loop")
+		return nil
+	}
 	interval := cfg.PriceFeed.RefreshInterval
 	if interval == 0 {
 		interval = 2 * time.Minute
 	}
-	cache := util.NewPriceCache(maxAge)
-	client := util.NewCoinGeckoClient(cfg.PriceFeed.BaseURL, cfg.PriceFeed.APIKey, cfg.PriceFeed.RequestTimeout)
 
 	runner, err := dispatcher.NewRunner(interval, func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), interval)
@@ -659,43 +682,169 @@ func startPriceFeed(cfg Configuration) (*util.PriceCache, dispatcher.Runner) {
 	if err := runner.Start(); err != nil {
 		log.Fatalf("failed to start price feed runner: %v", err)
 	}
-	return cache, runner
+	return runner
 }
 
-func collectCoinGeckoIDs(cfg Configuration) []string {
-	seen := make(map[string]struct{})
-	out := make([]string, 0)
-	for _, cc := range cfg.Cashiers {
-		for _, p := range cc.TokenPairs {
-			id := strings.ToLower(strings.TrimSpace(p.CoinGeckoID))
-			if id == "" {
-				continue
-			}
-			if _, dup := seen[id]; dup {
-				continue
-			}
-			seen[id] = struct{}{}
-			out = append(out, id)
+// collectCoinGeckoIDsFromMetas returns the deduped CoinGecko id list for the
+// price feed. After auto-resolution every TokenMeta with a USD-limit cashier
+// has its id populated; this is the canonical source.
+func collectCoinGeckoIDsFromMetas(metas []witness.TokenMeta) []string {
+	seen := make(map[string]struct{}, len(metas))
+	out := make([]string, 0, len(metas))
+	for _, m := range metas {
+		id := strings.ToLower(strings.TrimSpace(m.CoinGeckoID))
+		if id == "" {
+			continue
 		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
 	return out
 }
 
+// coingeckoPlatformForChain maps witness chain identifiers to CoinGecko's
+// asset-platform string (used in /coins/{platform}/contract/{address}).
+// Returns "" when no mapping is known — caller treats that as
+// "auto-resolution unavailable on this chain".
+func coingeckoPlatformForChain(chain string) string {
+	switch chain {
+	case "ethereum", "sepolia":
+		return "ethereum"
+	case "bsc":
+		return "binance-smart-chain"
+	case "matic":
+		return "polygon-pos"
+	case "iotex", "iotex-e", "iotex-testnet":
+		return "iotex"
+	case "solana":
+		return "solana"
+	case "heco":
+		return "huobi-token"
+	case "polis":
+		return "polis-chain"
+	}
+	return ""
+}
+
+// coingeckoNativeIDForChain returns the CoinGecko id for the chain's native
+// gas token, used when a TokenPair has the zero address as its token1
+// (currently no in-tree config does, but the future-proofing is cheap).
+func coingeckoNativeIDForChain(chain string) string {
+	switch chain {
+	case "ethereum", "sepolia":
+		return "ethereum"
+	case "bsc":
+		return "binancecoin"
+	case "matic":
+		return "matic-network"
+	case "iotex", "iotex-e", "iotex-testnet":
+		return "iotex"
+	case "solana":
+		return "solana"
+	}
+	return ""
+}
+
+// coingeckoResolver auto-resolves CoinGecko ids from token contract
+// addresses for the witness's bound chain. A nil resolver means
+// auto-resolution is disabled (price feed off or chain not mapped); callers
+// fall back to whatever id was set explicitly in config. Results are cached
+// in-process so repeated lookups (same token across multiple cashiers) make
+// at most one HTTP call.
+type coingeckoResolver struct {
+	client   *util.CoinGeckoClient
+	chain    string
+	platform string
+	cache    map[string]string // key: lowercase hex addr with 0x → CG id ("" = lookup failed)
+}
+
+func newCoingeckoResolver(client *util.CoinGeckoClient, chain string) *coingeckoResolver {
+	if client == nil {
+		return nil
+	}
+	platform := coingeckoPlatformForChain(chain)
+	if platform == "" {
+		log.Printf("coingecko: no platform mapping for chain %q; auto-resolution disabled (config must set coingeckoID)", chain)
+		return nil
+	}
+	return &coingeckoResolver{
+		client:   client,
+		chain:    chain,
+		platform: platform,
+		cache:    make(map[string]string),
+	}
+}
+
+// resolveByEthAddress looks up the CoinGecko id for an EVM contract address.
+// Returns "" if the resolver is nil, the chain has no platform mapping, or
+// the API has no record — in any of those cases the caller's existing
+// fallback (config override or buildApprovalGuard's hard check) takes over.
+func (r *coingeckoResolver) resolveByEthAddress(addr common.Address) string {
+	if r == nil {
+		return ""
+	}
+	key := strings.ToLower(addr.Hex())
+	if id, ok := r.cache[key]; ok {
+		return id
+	}
+	if isZeroEthAddress(key) {
+		id := coingeckoNativeIDForChain(r.chain)
+		r.cache[key] = id
+		return id
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	id, err := r.client.ResolveIDByContract(ctx, r.platform, key)
+	if err != nil {
+		if errors.Is(err, util.ErrCoinGeckoIDNotFound) {
+			log.Printf("coingecko: no coin indexed for %s/%s", r.platform, key)
+		} else {
+			log.Printf("coingecko: auto-resolve failed for %s/%s: %v", r.platform, key, err)
+		}
+		r.cache[key] = ""
+		return ""
+	}
+	r.cache[key] = id
+	log.Printf("coingecko: %s/%s → %s", r.platform, key, id)
+	return id
+}
+
+func isZeroEthAddress(hexAddr string) bool {
+	h := strings.TrimPrefix(strings.ToLower(hexAddr), "0x")
+	if len(h) == 0 {
+		return false
+	}
+	for _, c := range h {
+		if c != '0' {
+			return false
+		}
+	}
+	return true
+}
+
 // tokenMetasForEthereum builds TokenMeta for an EVM cashier — token1 is an
-// 0x... 20-byte address.
-func tokenMetasForEthereum(pairs []TokenPair) []witness.TokenMeta {
+// 0x... 20-byte address. When resolver is non-nil and a pair omits
+// CoinGeckoID, the id is auto-resolved via CoinGecko's contract lookup.
+func tokenMetasForEthereum(pairs []TokenPair, resolver *coingeckoResolver) []witness.TokenMeta {
 	out := make([]witness.TokenMeta, 0, len(pairs))
 	for _, p := range pairs {
-		if p.CoinGeckoID == "" && p.Decimals == 0 {
+		if resolver == nil && p.CoinGeckoID == "" && p.Decimals == 0 {
 			continue
 		}
 		addr, err := util.ParseEthAddress(p.Token1)
 		if err != nil {
 			log.Fatalf("tokenMetasForEthereum: invalid token1 %s: %v", p.Token1, err)
 		}
+		cgID := p.CoinGeckoID
+		if cgID == "" {
+			cgID = resolver.resolveByEthAddress(common.BytesToAddress(addr.Bytes()))
+		}
 		out = append(out, witness.TokenMeta{
 			Token:       strings.ToLower(strings.TrimPrefix(addr.String(), "0x")),
-			CoinGeckoID: p.CoinGeckoID,
+			CoinGeckoID: cgID,
 			Decimals:    p.Decimals,
 		})
 	}
@@ -705,19 +854,23 @@ func tokenMetasForEthereum(pairs []TokenPair) []witness.TokenMeta {
 // tokenMetasForIotex handles `io1...` bech32 addresses (IoTeX source-chain
 // cashiers). util.ParseEthAddress also accepts io1 prefixes — verified via
 // existing call sites — so we reuse it.
-func tokenMetasForIotex(pairs []TokenPair) []witness.TokenMeta {
+func tokenMetasForIotex(pairs []TokenPair, resolver *coingeckoResolver) []witness.TokenMeta {
 	out := make([]witness.TokenMeta, 0, len(pairs))
 	for _, p := range pairs {
-		if p.CoinGeckoID == "" && p.Decimals == 0 {
+		if resolver == nil && p.CoinGeckoID == "" && p.Decimals == 0 {
 			continue
 		}
 		addr, err := util.ParseEthAddress(p.Token1)
 		if err != nil {
 			log.Fatalf("tokenMetasForIotex: invalid token1 %s: %v", p.Token1, err)
 		}
+		cgID := p.CoinGeckoID
+		if cgID == "" {
+			cgID = resolver.resolveByEthAddress(common.BytesToAddress(addr.Bytes()))
+		}
 		out = append(out, witness.TokenMeta{
 			Token:       strings.ToLower(strings.TrimPrefix(addr.String(), "0x")),
-			CoinGeckoID: p.CoinGeckoID,
+			CoinGeckoID: cgID,
 			Decimals:    p.Decimals,
 		})
 	}

--- a/witness-service/cmd/witness/main.go
+++ b/witness-service/cmd/witness/main.go
@@ -13,6 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math/big"
 	"net"
 	"os"
 	"regexp"
@@ -28,26 +29,58 @@ import (
 	"go.uber.org/config"
 
 	"github.com/iotexproject/ioTube/witness-service/db"
+	"github.com/iotexproject/ioTube/witness-service/dispatcher"
 	"github.com/iotexproject/ioTube/witness-service/util"
 	"github.com/iotexproject/ioTube/witness-service/witness"
 	"github.com/iotexproject/iotex-address/address"
 )
 
+// ApprovalConfig configures the new pre-sign security guards. When `enabled`
+// is false (or the block is absent) all guards are disabled and the witness
+// behaves as before.
+type ApprovalConfig struct {
+	Enabled           bool          `json:"enabled" yaml:"enabled"`
+	ServerListenAddr  string        `json:"serverListenAddr" yaml:"serverListenAddr"`
+	LarkCardWebHook   string        `json:"larkCardWebHook" yaml:"larkCardWebHook"`
+	LarkSigningSecret string        `json:"larkSigningSecret" yaml:"larkSigningSecret"`
+	WindowDuration    time.Duration `json:"windowDuration" yaml:"windowDuration"`
+	// ExplorerTxURL is the base URL for the source-chain block explorer's
+	// transaction page. The transfer hash is appended directly, so it must
+	// end with a slash or "?tx=" as appropriate.
+	// Example: "https://bscscan.com/tx/" or "https://iotexscan.io/tx/"
+	ExplorerTxURL string `json:"explorerTxURL" yaml:"explorerTxURL"`
+}
+
+// PriceFeedConfig configures the CoinGecko price source used by ApprovalGuard
+// to convert per-token amounts into USD. When `enabled` is false the witness
+// skips the refresh loop entirely; in that case any cashier with a USD limit
+// will fail closed (Block until a price is available).
+type PriceFeedConfig struct {
+	Enabled         bool          `json:"enabled" yaml:"enabled"`
+	BaseURL         string        `json:"baseURL" yaml:"baseURL"`
+	APIKey          string        `json:"apiKey" yaml:"apiKey"`
+	RefreshInterval time.Duration `json:"refreshInterval" yaml:"refreshInterval"`
+	MaxPriceAge     time.Duration `json:"maxPriceAge" yaml:"maxPriceAge"`
+	RequestTimeout  time.Duration `json:"requestTimeout" yaml:"requestTimeout"`
+}
+
 // Configuration defines the configuration of the witness service
 type Configuration struct {
-	Chain                 string        `json:"chain" yaml:"chain"`
-	ClientURL             string        `json:"clientURL" yaml:"clientURL"`
-	RelayerURL            string        `json:"relayerURL" yaml:"relayerURL"`
-	Database              db.Config     `json:"database" yaml:"database"`
-	PrivateKey            string        `json:"privateKey" yaml:"privateKey"`
-	SlackWebHook          string        `json:"slackWebHook" yaml:"slackWebHook"`
-	LarkWebHook           string        `json:"larkWebHook" yaml:"larkWebHook"`
-	ConfirmBlockNumber    int           `json:"confirmBlockNumber" yaml:"confirmBlockNumber"`
-	BatchSize             int           `json:"batchSize" yaml:"batchSize"`
-	Interval              time.Duration `json:"interval" yaml:"interval"`
-	GrpcPort              int           `json:"grpcPort" yaml:"grpcPort"`
-	GrpcProxyPort         int           `json:"grpcProxyPort" yaml:"grpcProxyPort"`
-	DisableTransferSubmit bool          `json:"disableTransferSubmit" yaml:"disableTransferSubmit"`
+	Chain                 string         `json:"chain" yaml:"chain"`
+	ClientURL             string         `json:"clientURL" yaml:"clientURL"`
+	RelayerURL            string         `json:"relayerURL" yaml:"relayerURL"`
+	Database              db.Config      `json:"database" yaml:"database"`
+	PrivateKey            string         `json:"privateKey" yaml:"privateKey"`
+	SlackWebHook          string         `json:"slackWebHook" yaml:"slackWebHook"`
+	LarkWebHook           string         `json:"larkWebHook" yaml:"larkWebHook"`
+	Approval              ApprovalConfig `json:"approval" yaml:"approval"`
+	PriceFeed             PriceFeedConfig `json:"priceFeed" yaml:"priceFeed"`
+	ConfirmBlockNumber    int            `json:"confirmBlockNumber" yaml:"confirmBlockNumber"`
+	BatchSize             int            `json:"batchSize" yaml:"batchSize"`
+	Interval              time.Duration  `json:"interval" yaml:"interval"`
+	GrpcPort              int            `json:"grpcPort" yaml:"grpcPort"`
+	GrpcProxyPort         int            `json:"grpcProxyPort" yaml:"grpcProxyPort"`
+	DisableTransferSubmit bool           `json:"disableTransferSubmit" yaml:"disableTransferSubmit"`
 	Cashiers              []struct {
 		ID                             string      `json:"id" yaml:"id"`
 		RelayerURL                     string      `json:"relayerURL" yaml:"relayerURL"`
@@ -69,8 +102,10 @@ type Configuration struct {
 			CashierContractAddress string   `json:"cashierContractAddress" yaml:"cashierContractAddress"`
 			Tokens                 []string `json:"tokens" yaml:"tokens"`
 		}
-		QPSLimit    uint32 `json:"qpsLimit" yaml:"qpsLimit"`
-		DisablePull bool   `json:"disablePull" yaml:"disablePull"`
+		QPSLimit           uint32 `json:"qpsLimit" yaml:"qpsLimit"`
+		DisablePull        bool   `json:"disablePull" yaml:"disablePull"`
+		WindowValueLimit   string `json:"windowValueLimit" yaml:"windowValueLimit"`
+		SingleTxValueLimit string `json:"singleTxValueLimit" yaml:"singleTxValueLimit"`
 	} `json:"cashiers" yaml:"cashiers"`
 }
 
@@ -81,6 +116,14 @@ type TokenPair struct {
 	TokenMint      string   `json:"tokenMint" yaml:"tokenMint"`
 	TokenProgramID string   `json:"tokenProgramID,omitempty" yaml:"tokenProgramID,omitempty"`
 	Whitelist      []string `json:"whitelist" yaml:"whitelist"`
+	// CoinGeckoID is the CoinGecko coin id (e.g. "weth", "wrapped-bitcoin")
+	// used to fetch this token's USD price. Required when the parent cashier
+	// has a USD windowValueLimit or singleTxValueLimit configured.
+	CoinGeckoID string `json:"coingeckoID" yaml:"coingeckoID"`
+	// Decimals is the number of decimal places of the value returned by
+	// AbstractTransfer.Amount() — i.e. after any DecimalRound adjustment.
+	// Required when the parent cashier has a USD limit configured.
+	Decimals int `json:"decimals" yaml:"decimals"`
 }
 
 var (
@@ -227,6 +270,12 @@ func main() {
 		}
 	}
 
+	approvalGuards := make(map[string]*witness.ApprovalGuard)
+	priceCache, priceRunner := startPriceFeed(cfg)
+	if priceRunner != nil {
+		defer priceRunner.Close()
+	}
+
 	storeFactory := db.NewSQLStoreFactory()
 	cashiers := make([]witness.TokenCashier, 0, len(cfg.Cashiers))
 	switch cfg.Chain {
@@ -268,19 +317,21 @@ func main() {
 				log.Println("No Private Key")
 			}
 
+			cashierPubKey := solcommon.PublicKeyFromString(cc.CashierContractAddress)
+			solRecorder := witness.NewSOLRecorder(
+				storeFactory.NewStore(cfg.Database),
+				cc.TransferTableName,
+				pairs,
+				decimalRound,
+				destAddrDecoder,
+			)
 			cashier, err := witness.NewTokenCashierOnSolana(
 				cc.ID,
 				cc.RelayerURL,
 				solClient,
-				solcommon.PublicKeyFromString(cc.CashierContractAddress),
+				cashierPubKey,
 				common.BytesToAddress(addr.Bytes()),
-				witness.NewSOLRecorder(
-					storeFactory.NewStore(cfg.Database),
-					cc.TransferTableName,
-					pairs,
-					decimalRound,
-					destAddrDecoder,
-				),
+				solRecorder,
 				uint64(cc.StartBlockHeight),
 				cc.QPSLimit,
 				signHandler,
@@ -392,6 +443,29 @@ func main() {
 				decimalRound[common.BytesToAddress(addr.Bytes())] = r.Amount
 			}
 
+			ethRecorder := witness.NewRecorder(
+				storeFactory.NewStore(cfg.Database),
+				cc.TransferTableName,
+				pairs,
+				whitelists,
+				tokenMintPairs,
+				decimalRound,
+				destAddrDecoder,
+			)
+			cashierKey := cashierAddr.Hex()
+			var ethTokenMetas []witness.TokenMeta
+			if cc.ToSolana {
+				// For ETH→SOL cashiers token1 is still an EVM address; same path.
+				ethTokenMetas = tokenMetasForEthereum(cc.TokenPairs)
+			} else if cfg.Chain == "iotex" || cfg.Chain == "iotex-e" || cfg.Chain == "iotex-testnet" {
+				ethTokenMetas = tokenMetasForIotex(cc.TokenPairs)
+			} else {
+				ethTokenMetas = tokenMetasForEthereum(cc.TokenPairs)
+			}
+			guard := buildApprovalGuard(cfg.Approval, cashierKey, cc.WindowValueLimit, cc.SingleTxValueLimit, ethTokenMetas, priceCache, ethRecorder)
+			if guard != nil {
+				approvalGuards[cashierKey] = guard
+			}
 			cashier, err := witness.NewTokenCashierOnEthereum(
 				cc.ID,
 				version,
@@ -401,25 +475,30 @@ func main() {
 				previousCashierAddr,
 				tokenSafeAddr,
 				validatorAddr.Bytes(),
-				witness.NewRecorder(
-					storeFactory.NewStore(cfg.Database),
-					cc.TransferTableName,
-					pairs,
-					whitelists,
-					tokenMintPairs,
-					decimalRound,
-					destAddrDecoder,
-				),
+				ethRecorder,
 				uint64(cc.StartBlockHeight),
 				uint8(cfg.ConfirmBlockNumber),
 				signHandler,
 				reverseRecorder,
 				common.HexToAddress(cc.Reverse.CashierContractAddress),
+				guard,
 			)
 			if err != nil {
 				log.Fatalf("failed to create cashier %v\n", err)
 			}
 			cashiers = append(cashiers, cashier)
+		}
+	}
+
+	if cfg.Approval.Enabled {
+		if cfg.Approval.ServerListenAddr == "" {
+			log.Fatal("approval is enabled but approval.serverListenAddr is not configured")
+		}
+		if len(approvalGuards) == 0 {
+			log.Fatal("approval is enabled but no cashier has windowValueLimit or singleTxValueLimit configured")
+		}
+		if err := witness.NewApprovalServer(cfg.Approval.ServerListenAddr, cfg.Approval.LarkSigningSecret, approvalGuards).Start(); err != nil {
+			log.Fatalf("failed to start approval server: %v\n", err)
 		}
 	}
 
@@ -472,4 +551,175 @@ func main() {
 
 	log.Println("Serving...")
 	select {}
+}
+
+func buildApprovalGuard(
+	ac ApprovalConfig,
+	cashierKey string,
+	windowLimitStr, singleTxLimitStr string,
+	tokens []witness.TokenMeta,
+	prices witness.PriceSource,
+	recorder witness.AbstractRecorder,
+) *witness.ApprovalGuard {
+	if !ac.Enabled {
+		return nil
+	}
+	windowLimit := parseUsdLimit(windowLimitStr)
+	singleTxLimit := parseUsdLimit(singleTxLimitStr)
+	if windowLimit == nil && singleTxLimit == nil {
+		return nil
+	}
+	if prices == nil {
+		log.Fatalf("approval guard for %s configured with USD limit but no price source", cashierKey)
+	}
+	for _, tk := range tokens {
+		if tk.CoinGeckoID == "" || tk.Decimals < 0 {
+			log.Fatalf(
+				"approval guard for %s: token %s missing coingeckoID or has negative decimals (have id=%q decimals=%d)",
+				cashierKey, tk.Token, tk.CoinGeckoID, tk.Decimals,
+			)
+		}
+	}
+	return witness.NewApprovalGuard(
+		cashierKey,
+		ac.WindowDuration,
+		windowLimit,
+		singleTxLimit,
+		tokens,
+		prices,
+		recorder,
+		ac.LarkCardWebHook,
+		ac.ExplorerTxURL,
+	)
+}
+
+// parseUsdLimit parses a decimal USD amount (e.g. "100000", "5000.50") into a
+// *big.Float. Empty / "0" / non-positive values disable that limit dimension.
+func parseUsdLimit(s string) *big.Float {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "0" {
+		return nil
+	}
+	v, _, err := big.ParseFloat(s, 10, 80, big.ToNearestEven)
+	if err != nil {
+		log.Fatalf("invalid USD limit %q in approval config: %v", s, err)
+	}
+	if v.Sign() <= 0 {
+		return nil
+	}
+	return v
+}
+
+// startPriceFeed builds the shared *util.PriceCache and a periodic refresh
+// runner. When priceFeed.enabled is false (or no cashier needs prices) returns
+// (nil, nil) — the witness behaves exactly as it did before USD limits existed.
+// The runner is owned by the caller and must be Close()'d before exit.
+func startPriceFeed(cfg Configuration) (*util.PriceCache, dispatcher.Runner) {
+	if !cfg.PriceFeed.Enabled {
+		return nil, nil
+	}
+	ids := collectCoinGeckoIDs(cfg)
+	if len(ids) == 0 {
+		log.Println("priceFeed.enabled=true but no token pair declares coingeckoID; skipping refresh loop")
+		return nil, nil
+	}
+	maxAge := cfg.PriceFeed.MaxPriceAge
+	if maxAge == 0 {
+		maxAge = 10 * time.Minute
+	}
+	interval := cfg.PriceFeed.RefreshInterval
+	if interval == 0 {
+		interval = 2 * time.Minute
+	}
+	cache := util.NewPriceCache(maxAge)
+	client := util.NewCoinGeckoClient(cfg.PriceFeed.BaseURL, cfg.PriceFeed.APIKey, cfg.PriceFeed.RequestTimeout)
+
+	runner, err := dispatcher.NewRunner(interval, func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), interval)
+		defer cancel()
+		prices, err := client.FetchUSDPrices(ctx, ids)
+		if err != nil {
+			util.Alert(fmt.Sprintf("price feed refresh failed: %v", err))
+			return err
+		}
+		cache.Replace(prices)
+		return nil
+	})
+	if err != nil {
+		log.Fatalf("failed to create price feed runner: %v", err)
+	}
+	// Run once synchronously so guards have prices before signing starts.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if prices, err := client.FetchUSDPrices(ctx, ids); err != nil {
+		log.Printf("initial price fetch failed (will retry on schedule): %v", err)
+	} else {
+		cache.Replace(prices)
+	}
+	if err := runner.Start(); err != nil {
+		log.Fatalf("failed to start price feed runner: %v", err)
+	}
+	return cache, runner
+}
+
+func collectCoinGeckoIDs(cfg Configuration) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, cc := range cfg.Cashiers {
+		for _, p := range cc.TokenPairs {
+			id := strings.ToLower(strings.TrimSpace(p.CoinGeckoID))
+			if id == "" {
+				continue
+			}
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// tokenMetasForEthereum builds TokenMeta for an EVM cashier — token1 is an
+// 0x... 20-byte address.
+func tokenMetasForEthereum(pairs []TokenPair) []witness.TokenMeta {
+	out := make([]witness.TokenMeta, 0, len(pairs))
+	for _, p := range pairs {
+		if p.CoinGeckoID == "" && p.Decimals == 0 {
+			continue
+		}
+		addr, err := util.ParseEthAddress(p.Token1)
+		if err != nil {
+			log.Fatalf("tokenMetasForEthereum: invalid token1 %s: %v", p.Token1, err)
+		}
+		out = append(out, witness.TokenMeta{
+			Token:       strings.ToLower(strings.TrimPrefix(addr.String(), "0x")),
+			CoinGeckoID: p.CoinGeckoID,
+			Decimals:    p.Decimals,
+		})
+	}
+	return out
+}
+
+// tokenMetasForIotex handles `io1...` bech32 addresses (IoTeX source-chain
+// cashiers). util.ParseEthAddress also accepts io1 prefixes — verified via
+// existing call sites — so we reuse it.
+func tokenMetasForIotex(pairs []TokenPair) []witness.TokenMeta {
+	out := make([]witness.TokenMeta, 0, len(pairs))
+	for _, p := range pairs {
+		if p.CoinGeckoID == "" && p.Decimals == 0 {
+			continue
+		}
+		addr, err := util.ParseEthAddress(p.Token1)
+		if err != nil {
+			log.Fatalf("tokenMetasForIotex: invalid token1 %s: %v", p.Token1, err)
+		}
+		out = append(out, witness.TokenMeta{
+			Token:       strings.ToLower(strings.TrimPrefix(addr.String(), "0x")),
+			CoinGeckoID: p.CoinGeckoID,
+			Decimals:    p.Decimals,
+		})
+	}
+	return out
 }

--- a/witness-service/docs/missing-transaction-runbook.md
+++ b/witness-service/docs/missing-transaction-runbook.md
@@ -61,3 +61,12 @@ stops appearing in `StaleHeights`.
 Click **Mute** on the Lark card so this witness stops retrying/alerting on that
 height. Mute is in-memory: if the witness restarts before the transfer settles,
 the alert may reappear once — just Mute again.
+
+> The **Mute** button only exists when the approval guard is enabled and a
+> `larkCardWebHook` is configured for that cashier. Without them the witness can
+> only emit a text alert (no Mute); resolve the transfer manually (Steps 1–3) to
+> stop it, or restart the witness once it is no longer stale.
+>
+> Note: the alert is only raised for heights at or below the witness's current
+> tip. A stale height above the tip means the witness is still catching up (not
+> missing data) and is skipped silently until the tip advances.

--- a/witness-service/docs/missing-transaction-runbook.md
+++ b/witness-service/docs/missing-transaction-runbook.md
@@ -1,0 +1,63 @@
+# Runbook: missing / deleted source transaction
+
+## When you see this alert
+
+A witness received a "stale height" from the relayer but the source chain's
+node/API has pruned that block, so the witness cannot fetch the transfer to
+sign it. The transfer is stuck `new` on the relayer; the witness re-tries and
+re-alerts every tick until it is resolved.
+
+The alert arrives as a Lark card carrying the **cashier** and **block height**,
+with a single **Mute** button.
+
+You have two choices:
+
+1. **Resolve it** — sign & submit manually (below), then Mute.
+2. **Abandon it** — just click Mute (only if the transfer should never settle).
+
+## Step 1 — Find the missing transaction(s)
+
+You have the cashier address and block height from the alert.
+
+- Relayer DB:
+
+  ```sql
+  SELECT token, tidx, sender, recipient, amount, payload, sourceTxHash
+  FROM transfers
+  WHERE cashier = '<cashier>' AND blockHeight = <height> AND status = 'new';
+  ```
+
+  (Or use the relayer `List` / `Lookup` gRPC.)
+- Cross-check on the block explorer: open the cashier contract at that height
+  and confirm the Receipt event's token / index / sender / recipient / amount.
+
+> Note: `token` in the relayer row is the **co-token on the destination chain**
+> — that is the `-cotoken` value below.
+
+## Step 2 — Sign (offline, no API needed)
+
+```sh
+sign-witness -config <witness-config.yaml> -secret <secret.yaml> -cashier <cashier-id> \
+  -cotoken <coToken> -index <tidx> -sender <sender> -recipient <recipient> -amount <amount> \
+  [-payload <hex>] [-to-solana]
+```
+
+Copy the printed `Signature` and `Transfer ID`.
+
+## Step 3 — Submit to the relayer
+
+```sh
+submit-witness -config <relayer-config.yaml> -secret <secret.yaml> \
+  -validator <validator> -cashier <cashier> -token <coToken> -index <tidx> \
+  -sender <sender> -recipient <recipient> -amount <amount> [-payload <hex>] \
+  -signatures <sig-from-step-2> -dry-run    # inspect first, then re-run without -dry-run
+```
+
+Once enough witnesses' signatures land, the relayer settles the transfer and it
+stops appearing in `StaleHeights`.
+
+## Step 4 — Mute
+
+Click **Mute** on the Lark card so this witness stops retrying/alerting on that
+height. Mute is in-memory: if the witness restarts before the transfer settles,
+the alert may reappear once — just Mute again.

--- a/witness-service/util/coingecko.go
+++ b/witness-service/util/coingecko.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultCoinGeckoBaseURL is the public, free-tier endpoint.
+	DefaultCoinGeckoBaseURL = "https://api.coingecko.com/api/v3"
+
+	coingeckoSimplePricePath = "/simple/price"
+)
+
+// CoinGeckoClient is a minimal HTTP client for the /simple/price endpoint.
+type CoinGeckoClient struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewCoinGeckoClient builds a client. baseURL falls back to the free public
+// endpoint when empty. apiKey is sent in the `x-cg-pro-api-key` header when set
+// (CoinGecko Pro / Demo / Analyst plans). timeout=0 ⇒ 10s default.
+func NewCoinGeckoClient(baseURL, apiKey string, timeout time.Duration) *CoinGeckoClient {
+	if baseURL == "" {
+		baseURL = DefaultCoinGeckoBaseURL
+	}
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+	return &CoinGeckoClient{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: timeout},
+	}
+}
+
+// FetchUSDPrices issues a single batched GET /simple/price?ids=...&vs_currencies=usd
+// and returns a map keyed by the CoinGecko id (as returned by the API, lower-case
+// per CoinGecko's convention). Missing ids in the response are simply absent
+// from the returned map — the caller decides how to react.
+func (c *CoinGeckoClient) FetchUSDPrices(ctx context.Context, ids []string) (map[string]*big.Float, error) {
+	if len(ids) == 0 {
+		return map[string]*big.Float{}, nil
+	}
+	uniq := make([]string, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		id = strings.ToLower(strings.TrimSpace(id))
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniq = append(uniq, id)
+	}
+
+	q := url.Values{}
+	q.Set("ids", strings.Join(uniq, ","))
+	q.Set("vs_currencies", "usd")
+	endpoint := c.baseURL + coingeckoSimplePricePath + "?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("x-cg-pro-api-key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("coingecko price fetch failed: status=%d body=%s", resp.StatusCode, string(body))
+	}
+
+	// Response shape: { "weth": {"usd": 3456.78}, "wrapped-bitcoin": {"usd": 65000.1} }
+	var raw map[string]map[string]json.Number
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode coingecko response: %w", err)
+	}
+	out := make(map[string]*big.Float, len(raw))
+	for id, m := range raw {
+		n, ok := m["usd"]
+		if !ok {
+			continue
+		}
+		f, _, err := big.ParseFloat(string(n), 10, 80, big.ToNearestEven)
+		if err != nil {
+			return nil, fmt.Errorf("parse price for %s (%q): %w", id, string(n), err)
+		}
+		out[strings.ToLower(id)] = f
+	}
+	return out, nil
+}
+
+// PriceCache is a process-wide cache of last-known USD prices. A nil cache is
+// not valid — always use NewPriceCache. Concurrent reads/writes are safe.
+type PriceCache struct {
+	mu     sync.RWMutex
+	prices map[string]priceEntry
+	maxAge time.Duration
+	now    func() time.Time // injectable for tests
+}
+
+type priceEntry struct {
+	usd       *big.Float
+	fetchedAt time.Time
+}
+
+// NewPriceCache returns a cache whose entries are considered stale once their
+// fetchedAt is more than maxAge in the past. maxAge=0 disables the staleness
+// check (entries are always fresh as long as they exist).
+func NewPriceCache(maxAge time.Duration) *PriceCache {
+	return &PriceCache{
+		prices: make(map[string]priceEntry),
+		maxAge: maxAge,
+		now:    time.Now,
+	}
+}
+
+// SetNowFunc overrides the clock for tests. Production code should not call this.
+func (p *PriceCache) SetNowFunc(now func() time.Time) {
+	p.mu.Lock()
+	p.now = now
+	p.mu.Unlock()
+}
+
+// Replace overwrites the cache with the given prices, stamping fetchedAt = now.
+// Ids missing from `prices` are NOT evicted — they retain their previous
+// fetchedAt and will age out via maxAge. This matches the user's fail-closed
+// policy: a transient outage that returns fewer ids than expected does not
+// silently widen the limit window.
+func (p *PriceCache) Replace(prices map[string]*big.Float) {
+	if len(prices) == 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := p.now()
+	for id, v := range prices {
+		if v == nil {
+			continue
+		}
+		p.prices[strings.ToLower(id)] = priceEntry{usd: new(big.Float).Copy(v), fetchedAt: now}
+	}
+}
+
+// Price returns (usdPrice, true) if `id` has a fresh cached value, otherwise
+// (nil, false). The returned *big.Float is a copy — callers may mutate freely.
+func (p *PriceCache) Price(id string) (*big.Float, bool) {
+	id = strings.ToLower(strings.TrimSpace(id))
+	if id == "" {
+		return nil, false
+	}
+	p.mu.RLock()
+	entry, ok := p.prices[id]
+	now := p.now()
+	maxAge := p.maxAge
+	p.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if maxAge > 0 && now.Sub(entry.fetchedAt) > maxAge {
+		return nil, false
+	}
+	return new(big.Float).Copy(entry.usd), true
+}

--- a/witness-service/util/coingecko.go
+++ b/witness-service/util/coingecko.go
@@ -9,6 +9,7 @@ package util
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -18,6 +19,12 @@ import (
 	"sync"
 	"time"
 )
+
+// ErrCoinGeckoIDNotFound is returned by ResolveIDByContract when CoinGecko
+// has no coin record for the given (platform, contract address) pair. Callers
+// should match on this with errors.Is to distinguish "not indexed" from a
+// transient transport failure.
+var ErrCoinGeckoIDNotFound = errors.New("coingecko: no coin id for given contract address")
 
 const (
 	// DefaultCoinGeckoBaseURL is the public, free-tier endpoint.
@@ -114,6 +121,62 @@ func (c *CoinGeckoClient) FetchUSDPrices(ctx context.Context, ids []string) (map
 		out[strings.ToLower(id)] = f
 	}
 	return out, nil
+}
+
+// ResolveIDByContract looks up the CoinGecko coin id for a token by its
+// on-chain contract address. `platform` is CoinGecko's asset-platform string
+// ("ethereum", "binance-smart-chain", "polygon-pos", "iotex", "solana", ...).
+// `address` should be the address in the form the platform expects — hex with
+// 0x prefix for EVM platforms, base58 for Solana. Returns
+// ErrCoinGeckoIDNotFound when the API responds 404, which lets callers
+// distinguish "this token isn't indexed on this chain" from a real failure.
+func (c *CoinGeckoClient) ResolveIDByContract(ctx context.Context, platform, address string) (string, error) {
+	platform = strings.ToLower(strings.TrimSpace(platform))
+	address = strings.TrimSpace(address)
+	if platform == "" || address == "" {
+		return "", fmt.Errorf("coingecko: platform and address must be non-empty")
+	}
+	// CoinGecko's contract lookup is case-insensitive for EVM but accepts
+	// either; normalize EVM addresses to lowercase so logs and request paths
+	// are deterministic. Solana base58 addresses are case-sensitive — leave
+	// them alone.
+	if strings.HasPrefix(address, "0x") || strings.HasPrefix(address, "0X") {
+		address = strings.ToLower(address)
+	}
+	endpoint := c.baseURL + "/coins/" + url.PathEscape(platform) + "/contract/" + url.PathEscape(address)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("x-cg-pro-api-key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", ErrCoinGeckoIDNotFound
+	}
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return "", fmt.Errorf("coingecko contract lookup failed: status=%d body=%s", resp.StatusCode, string(body))
+	}
+
+	var payload struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode coingecko contract response: %w", err)
+	}
+	id := strings.ToLower(strings.TrimSpace(payload.ID))
+	if id == "" {
+		return "", ErrCoinGeckoIDNotFound
+	}
+	return id, nil
 }
 
 // PriceCache is a process-wide cache of last-known USD prices. A nil cache is

--- a/witness-service/util/coingecko_test.go
+++ b/witness-service/util/coingecko_test.go
@@ -8,6 +8,7 @@ package util
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -92,6 +93,64 @@ func TestCoinGeckoClient_DedupAndTrimIDs(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&called); got != 1 {
 		t.Fatalf("expected 1 HTTP call, got %d", got)
+	}
+}
+
+func TestCoinGeckoClient_ResolveIDByContract_Happy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/coins/ethereum/contract/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+		if r.URL.Path != want {
+			t.Errorf("unexpected path: got %q want %q", r.URL.Path, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"weth","symbol":"weth","name":"WETH"}`)
+	}))
+	defer srv.Close()
+
+	c := NewCoinGeckoClient(srv.URL, "", time.Second)
+	id, err := c.ResolveIDByContract(context.Background(), "ethereum", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// The CG-canonical id (lowercased) is what we send back; the input address
+	// case is preserved when we issue the request (CG is case-insensitive but
+	// the test asserts our normalization just lowercases the path components).
+	if id != "weth" {
+		t.Fatalf("id got %q want weth", id)
+	}
+}
+
+func TestCoinGeckoClient_ResolveIDByContract_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":"coin not found"}`)
+	}))
+	defer srv.Close()
+
+	c := NewCoinGeckoClient(srv.URL, "", time.Second)
+	_, err := c.ResolveIDByContract(context.Background(), "binance-smart-chain", "0x0000000000000000000000000000000000000bad")
+	if !errors.Is(err, ErrCoinGeckoIDNotFound) {
+		t.Fatalf("expected ErrCoinGeckoIDNotFound, got %v", err)
+	}
+}
+
+func TestCoinGeckoClient_ResolveIDByContract_TransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":"oops"}`)
+	}))
+	defer srv.Close()
+
+	c := NewCoinGeckoClient(srv.URL, "", time.Second)
+	_, err := c.ResolveIDByContract(context.Background(), "ethereum", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrCoinGeckoIDNotFound) {
+		t.Fatalf("500 should not surface as not-found, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error should mention status code, got %v", err)
 	}
 }
 

--- a/witness-service/util/coingecko_test.go
+++ b/witness-service/util/coingecko_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCoinGeckoClient_FetchUSDPrices_Happy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/simple/price" {
+			t.Errorf("unexpected path %q", got)
+		}
+		ids := r.URL.Query().Get("ids")
+		// Order-independent check.
+		want := map[string]bool{"weth": false, "wrapped-bitcoin": false}
+		for _, id := range strings.Split(ids, ",") {
+			if _, ok := want[id]; !ok {
+				t.Errorf("unexpected id %q in request", id)
+			}
+			want[id] = true
+		}
+		for id, seen := range want {
+			if !seen {
+				t.Errorf("expected id %q in request", id)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"weth": {"usd": 3456.78}, "wrapped-bitcoin": {"usd": 65000.1}}`)
+	}))
+	defer srv.Close()
+
+	c := NewCoinGeckoClient(srv.URL, "", time.Second)
+	prices, err := c.FetchUSDPrices(context.Background(), []string{"weth", "wrapped-bitcoin"})
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got, _ := prices["weth"].Float64(); got != 3456.78 {
+		t.Fatalf("weth got %v", got)
+	}
+	if got, _ := prices["wrapped-bitcoin"].Float64(); got != 65000.1 {
+		t.Fatalf("wbtc got %v", got)
+	}
+}
+
+func TestCoinGeckoClient_FetchUSDPrices_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprint(w, `{"error":"rate limited"}`)
+	}))
+	defer srv.Close()
+
+	c := NewCoinGeckoClient(srv.URL, "", time.Second)
+	_, err := c.FetchUSDPrices(context.Background(), []string{"weth"})
+	if err == nil {
+		t.Fatal("expected error on 429")
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Fatalf("error should mention status code, got: %v", err)
+	}
+}
+
+func TestCoinGeckoClient_DedupAndTrimIDs(t *testing.T) {
+	var called int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&called, 1)
+		ids := r.URL.Query().Get("ids")
+		// Trimmed + lowercased + deduped.
+		if ids != "weth,wbtc" && ids != "wbtc,weth" {
+			t.Errorf("unexpected ids param %q", ids)
+		}
+		fmt.Fprint(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c := NewCoinGeckoClient(srv.URL, "", time.Second)
+	_, err := c.FetchUSDPrices(context.Background(), []string{"WETH", " weth", "wbtc", "weth", ""})
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got := atomic.LoadInt32(&called); got != 1 {
+		t.Fatalf("expected 1 HTTP call, got %d", got)
+	}
+}
+
+func TestPriceCache_FreshnessWindow(t *testing.T) {
+	cache := NewPriceCache(5 * time.Minute)
+	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	cache.SetNowFunc(func() time.Time { return now })
+
+	cache.Replace(map[string]*big.Float{"weth": big.NewFloat(3000)})
+	if p, ok := cache.Price("weth"); !ok || p == nil {
+		t.Fatal("just-set price reported stale")
+	}
+
+	// Advance past maxAge → stale.
+	cache.SetNowFunc(func() time.Time { return now.Add(6 * time.Minute) })
+	if _, ok := cache.Price("weth"); ok {
+		t.Fatal("expected stale after maxAge")
+	}
+
+	// Refresh stamps a new fetchedAt.
+	cache.SetNowFunc(func() time.Time { return now.Add(7 * time.Minute) })
+	cache.Replace(map[string]*big.Float{"weth": big.NewFloat(3100)})
+	if p, ok := cache.Price("weth"); !ok || p == nil {
+		t.Fatal("post-refresh price reported stale")
+	} else if got, _ := p.Float64(); got != 3100 {
+		t.Fatalf("price got %v", got)
+	}
+}
+
+func TestPriceCache_MissingIDReturnsNotOK(t *testing.T) {
+	cache := NewPriceCache(time.Minute)
+	if _, ok := cache.Price("nothing"); ok {
+		t.Fatal("expected ok=false for missing id")
+	}
+}
+
+func TestPriceCache_CaseInsensitiveKeys(t *testing.T) {
+	cache := NewPriceCache(time.Minute)
+	cache.Replace(map[string]*big.Float{"WETH": big.NewFloat(3000)})
+	if _, ok := cache.Price("weth"); !ok {
+		t.Fatal("lookup should be case-insensitive")
+	}
+	if _, ok := cache.Price("WeTh"); !ok {
+		t.Fatal("lookup should be case-insensitive")
+	}
+}

--- a/witness-service/util/lark_card.go
+++ b/witness-service/util/lark_card.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package util
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// LarkApprovalRequest captures the fields rendered to the admin in the Lark
+// interactive card. All fields are pre-formatted strings.
+type LarkApprovalRequest struct {
+	TransferID string
+	Cashier    string
+	Token      string
+	Recipient  string
+	Amount     string  // raw token amount in base units
+	AmountUSD  string  // human-readable USD equivalent, e.g. "$61,234.56"; empty if unknown
+	TxHash     string
+	TxHashURL  string  // full explorer URL; if non-empty TxHash is rendered as a hyperlink
+	Nonce      string
+}
+
+// LarkCallback is the decoded payload from a Lark `card.action.trigger` event
+// targeting our approval handler.
+type LarkCallback struct {
+	OpenID     string
+	TransferID string
+	Cashier    string
+	Token      string
+	Tidx       uint64
+	Nonce      string
+	Timestamp  int64
+	// Action is "approve" or "reject" — set by the button the admin clicked.
+	Action string
+}
+
+// SendLarkApprovalCard posts an interactive card to a Lark bot incoming
+// webhook. The card carries the transfer details and Approve / Reject buttons.
+// The first admin to click either button locks the decision.
+func SendLarkApprovalCard(webhook string, req LarkApprovalRequest) error {
+	if webhook == "" {
+		return fmt.Errorf("lark webhook is empty")
+	}
+	approveValue := map[string]string{
+		"transferID": req.TransferID,
+		"cashier":    req.Cashier,
+		"token":      req.Token,
+		"nonce":      req.Nonce,
+		"action":     "approve",
+	}
+	rejectValue := map[string]string{
+		"transferID": req.TransferID,
+		"cashier":    req.Cashier,
+		"token":      req.Token,
+		"nonce":      req.Nonce,
+		"action":     "reject",
+	}
+	card := map[string]interface{}{
+		"config": map[string]bool{"wide_screen_mode": true},
+		"header": map[string]interface{}{
+			"template": "red",
+			"title": map[string]string{
+				"tag":     "plain_text",
+				"content": "Cross-chain transfer approval required",
+			},
+		},
+		"elements": []interface{}{
+			map[string]interface{}{
+				"tag": "div",
+				"text": map[string]string{
+					"tag":     "lark_md",
+					"content": buildCardBody(req),
+				},
+			},
+			map[string]interface{}{
+				"tag": "action",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"tag":  "button",
+						"type": "primary",
+						"text": map[string]string{
+							"tag":     "plain_text",
+							"content": "Approve",
+						},
+						"value": approveValue,
+					},
+					map[string]interface{}{
+						"tag":  "button",
+						"type": "danger",
+						"text": map[string]string{
+							"tag":     "plain_text",
+							"content": "Reject",
+						},
+						"value": rejectValue,
+					},
+				},
+			},
+		},
+	}
+	body, err := json.Marshal(map[string]interface{}{
+		"msg_type": "interactive",
+		"card":     card,
+	})
+	if err != nil {
+		return err
+	}
+	resp, err := http.Post(webhook, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("lark card post failed: status=%d body=%s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// buildCardBody assembles the Lark Markdown body shown to the admin. The TxHash
+// is rendered as a hyperlink when TxHashURL is set; AmountUSD is appended to
+// the Amount line when present.
+func buildCardBody(req LarkApprovalRequest) string {
+	amountLine := "**Amount:** " + req.Amount
+	if req.AmountUSD != "" {
+		amountLine += " (" + req.AmountUSD + ")"
+	}
+	txHashLine := "**TxHash:** "
+	if req.TxHashURL != "" {
+		txHashLine += fmt.Sprintf("[%s](%s)", req.TxHash, req.TxHashURL)
+	} else {
+		txHashLine += req.TxHash
+	}
+	return fmt.Sprintf(
+		"**Cashier:** %s\n**Token:** %s\n**Recipient:** %s\n%s\n%s",
+		req.Cashier, req.Token, req.Recipient, amountLine, txHashLine,
+	)
+}
+
+// VerifyLarkCallbackSignature implements Lark's HMAC-SHA256 signing scheme for
+// webhook event subscriptions: signature = base64(HMAC-SHA256(secret,
+// timestamp + "\n" + nonce + "\n" + body)). Reject on any mismatch — never
+// short-circuit comparison.
+func VerifyLarkCallbackSignature(secret, timestamp, nonce string, body []byte, gotB64 string) bool {
+	if secret == "" || gotB64 == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(timestamp))
+	mac.Write([]byte("\n"))
+	mac.Write([]byte(nonce))
+	mac.Write([]byte("\n"))
+	mac.Write(body)
+	want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(want), []byte(gotB64))
+}
+
+// DecodeLarkCardCallback parses a Lark `card.action.trigger` HTTP body into
+// our LarkCallback type. The event JSON shape we care about:
+//
+//	{
+//	  "event": {
+//	    "operator": { "open_id": "ou_..." },
+//	    "action":   { "value": { "transferID": "...", "cashier": "...", "token": "...", "tidx": 12, "nonce": "...", "action": "approve" } }
+//	  }
+//	}
+//
+// Extra fields are ignored.
+func DecodeLarkCardCallback(body []byte) (LarkCallback, error) {
+	var raw struct {
+		Timestamp string `json:"ts"`
+		Event     struct {
+			Operator struct {
+				OpenID string `json:"open_id"`
+			} `json:"operator"`
+			Action struct {
+				Value map[string]interface{} `json:"value"`
+			} `json:"action"`
+		} `json:"event"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return LarkCallback{}, err
+	}
+	out := LarkCallback{OpenID: raw.Event.Operator.OpenID}
+	if v, ok := raw.Event.Action.Value["transferID"].(string); ok {
+		out.TransferID = v
+	}
+	if v, ok := raw.Event.Action.Value["cashier"].(string); ok {
+		out.Cashier = v
+	}
+	if v, ok := raw.Event.Action.Value["token"].(string); ok {
+		out.Token = v
+	}
+	if v, ok := raw.Event.Action.Value["nonce"].(string); ok {
+		out.Nonce = v
+	}
+	if v, ok := raw.Event.Action.Value["action"].(string); ok {
+		out.Action = v
+	}
+	if v, ok := raw.Event.Action.Value["tidx"]; ok {
+		switch n := v.(type) {
+		case float64:
+			out.Tidx = uint64(n)
+		case string:
+			parsed, err := strconv.ParseUint(n, 10, 64)
+			if err == nil {
+				out.Tidx = parsed
+			}
+		}
+	}
+	if raw.Timestamp != "" {
+		if ts, err := strconv.ParseInt(raw.Timestamp, 10, 64); err == nil {
+			out.Timestamp = ts
+		}
+	}
+	return out, nil
+}
+
+// FreshTimestamp returns true iff `ts` (unix seconds, possibly with millis
+// stripped) is within ±maxSkew of `now`.
+func FreshTimestamp(ts int64, now time.Time, maxSkew time.Duration) bool {
+	if ts == 0 {
+		return false
+	}
+	delta := now.Unix() - ts
+	if delta < 0 {
+		delta = -delta
+	}
+	return time.Duration(delta)*time.Second <= maxSkew
+}

--- a/witness-service/util/lark_card.go
+++ b/witness-service/util/lark_card.go
@@ -37,9 +37,14 @@ type LarkApprovalRequest struct {
 // cannot fetch a stale block's source data (e.g. the source chain/API pruned
 // that history). The card carries a single Mute button.
 type LarkStaleWarning struct {
+	// Cashier is the contract the stale height belongs to, shown in the card.
 	Cashier string
-	Height  uint64
-	Nonce   string
+	// GuardKey routes the Mute callback back to the guard that posted the card.
+	// It can differ from Cashier when the height belongs to a previous cashier.
+	// When empty, Cashier is used.
+	GuardKey string
+	Height   uint64
+	Nonce    string
 }
 
 // LarkCallback is the decoded payload from a Lark `card.action.trigger` event
@@ -63,9 +68,6 @@ type LarkCallback struct {
 // webhook. The card carries the transfer details and Approve / Reject buttons.
 // The first admin to click either button locks the decision.
 func SendLarkApprovalCard(webhook string, req LarkApprovalRequest) error {
-	if webhook == "" {
-		return fmt.Errorf("lark webhook is empty")
-	}
 	approveValue := map[string]string{
 		"transferID": req.TransferID,
 		"cashier":    req.Cashier,
@@ -122,6 +124,16 @@ func SendLarkApprovalCard(webhook string, req LarkApprovalRequest) error {
 			},
 		},
 	}
+	return postLarkInteractiveCard(webhook, card)
+}
+
+// postLarkInteractiveCard marshals `card` as a Lark interactive message and
+// POSTs it to the incoming-webhook URL. Shared by all card senders so the
+// webhook check, JSON envelope, and HTTP error handling live in one place.
+func postLarkInteractiveCard(webhook string, card interface{}) error {
+	if webhook == "" {
+		return fmt.Errorf("lark webhook is empty")
+	}
 	body, err := json.Marshal(map[string]interface{}{
 		"msg_type": "interactive",
 		"card":     card,
@@ -145,12 +157,15 @@ func SendLarkApprovalCard(webhook string, req LarkApprovalRequest) error {
 // cannot fetch a stale block's source data. The single Mute button records the
 // (cashier, height) so the witness stops retrying/alerting on that height.
 func SendLarkStaleWarningCard(webhook string, req LarkStaleWarning) error {
-	if webhook == "" {
-		return fmt.Errorf("lark webhook is empty")
-	}
 	heightStr := strconv.FormatUint(req.Height, 10)
+	// The Mute callback must route to the guard that posted the card; that is
+	// GuardKey, which can differ from the displayed (owning) cashier.
+	routeCashier := req.GuardKey
+	if routeCashier == "" {
+		routeCashier = req.Cashier
+	}
 	muteValue := map[string]string{
-		"cashier": req.Cashier,
+		"cashier": routeCashier,
 		"height":  heightStr,
 		"nonce":   req.Nonce,
 		"action":  "mute",
@@ -197,23 +212,7 @@ func SendLarkStaleWarningCard(webhook string, req LarkStaleWarning) error {
 			},
 		},
 	}
-	payload, err := json.Marshal(map[string]interface{}{
-		"msg_type": "interactive",
-		"card":     card,
-	})
-	if err != nil {
-		return err
-	}
-	resp, err := http.Post(webhook, "application/json", bytes.NewReader(payload))
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("lark card post failed: status=%d body=%s", resp.StatusCode, string(respBody))
-	}
-	return nil
+	return postLarkInteractiveCard(webhook, card)
 }
 
 // buildCardBody assembles the Lark Markdown body shown to the admin. The TxHash
@@ -252,6 +251,23 @@ func VerifyLarkCallbackSignature(secret, timestamp, nonce string, body []byte, g
 	mac.Write(body)
 	want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
 	return hmac.Equal([]byte(want), []byte(gotB64))
+}
+
+// uint64FromValue extracts a uint64 from a decoded JSON action value, which may
+// arrive as a float64 (JSON number) or a decimal string. Returns ok=false when
+// the value is absent or not parseable.
+func uint64FromValue(v interface{}) (uint64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return uint64(n), true
+	case string:
+		parsed, err := strconv.ParseUint(n, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	}
+	return 0, false
 }
 
 // DecodeLarkCardCallback parses a Lark `card.action.trigger` HTTP body into
@@ -296,27 +312,11 @@ func DecodeLarkCardCallback(body []byte) (LarkCallback, error) {
 	if v, ok := raw.Event.Action.Value["action"].(string); ok {
 		out.Action = v
 	}
-	if v, ok := raw.Event.Action.Value["tidx"]; ok {
-		switch n := v.(type) {
-		case float64:
-			out.Tidx = uint64(n)
-		case string:
-			parsed, err := strconv.ParseUint(n, 10, 64)
-			if err == nil {
-				out.Tidx = parsed
-			}
-		}
+	if v, ok := uint64FromValue(raw.Event.Action.Value["tidx"]); ok {
+		out.Tidx = v
 	}
-	if v, ok := raw.Event.Action.Value["height"]; ok {
-		switch n := v.(type) {
-		case float64:
-			out.Height = uint64(n)
-		case string:
-			parsed, err := strconv.ParseUint(n, 10, 64)
-			if err == nil {
-				out.Height = parsed
-			}
-		}
+	if v, ok := uint64FromValue(raw.Event.Action.Value["height"]); ok {
+		out.Height = v
 	}
 	if raw.Timestamp != "" {
 		if ts, err := strconv.ParseInt(raw.Timestamp, 10, 64); err == nil {

--- a/witness-service/util/lark_card.go
+++ b/witness-service/util/lark_card.go
@@ -33,6 +33,15 @@ type LarkApprovalRequest struct {
 	Nonce      string
 }
 
+// LarkStaleWarning captures the fields rendered to the admin when a witness
+// cannot fetch a stale block's source data (e.g. the source chain/API pruned
+// that history). The card carries a single Mute button.
+type LarkStaleWarning struct {
+	Cashier string
+	Height  uint64
+	Nonce   string
+}
+
 // LarkCallback is the decoded payload from a Lark `card.action.trigger` event
 // targeting our approval handler.
 type LarkCallback struct {
@@ -41,9 +50,12 @@ type LarkCallback struct {
 	Cashier    string
 	Token      string
 	Tidx       uint64
-	Nonce      string
-	Timestamp  int64
-	// Action is "approve" or "reject" — set by the button the admin clicked.
+	// Height is the stale block height carried by a "mute" card.
+	Height    uint64
+	Nonce     string
+	Timestamp int64
+	// Action is "approve", "reject", or "mute" — set by the button the admin
+	// clicked.
 	Action string
 }
 
@@ -118,6 +130,81 @@ func SendLarkApprovalCard(webhook string, req LarkApprovalRequest) error {
 		return err
 	}
 	resp, err := http.Post(webhook, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("lark card post failed: status=%d body=%s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// SendLarkStaleWarningCard posts an interactive card warning that a witness
+// cannot fetch a stale block's source data. The single Mute button records the
+// (cashier, height) so the witness stops retrying/alerting on that height.
+func SendLarkStaleWarningCard(webhook string, req LarkStaleWarning) error {
+	if webhook == "" {
+		return fmt.Errorf("lark webhook is empty")
+	}
+	heightStr := strconv.FormatUint(req.Height, 10)
+	muteValue := map[string]string{
+		"cashier": req.Cashier,
+		"height":  heightStr,
+		"nonce":   req.Nonce,
+		"action":  "mute",
+	}
+	body := fmt.Sprintf(
+		"**Cashier:** %s\n**Block height:** %s\n\n"+
+			"The relayer asked this witness to re-pull block **%s**, but the source chain/API no "+
+			"longer has that block's data, so this transfer **cannot be signed automatically**.\n\n"+
+			"**Action required:** find, sign, and submit it manually (see runbook), then click "+
+			"**Mute** to stop these alerts. Clicking **Mute** without signing abandons the transfer "+
+			"on this witness.",
+		req.Cashier, heightStr, heightStr,
+	)
+	card := map[string]interface{}{
+		"config": map[string]bool{"wide_screen_mode": true},
+		"header": map[string]interface{}{
+			"template": "orange",
+			"title": map[string]string{
+				"tag":     "plain_text",
+				"content": "⚠️ Witness can't fetch transfer — source data deleted",
+			},
+		},
+		"elements": []interface{}{
+			map[string]interface{}{
+				"tag": "div",
+				"text": map[string]string{
+					"tag":     "lark_md",
+					"content": body,
+				},
+			},
+			map[string]interface{}{
+				"tag": "action",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"tag":  "button",
+						"type": "danger",
+						"text": map[string]string{
+							"tag":     "plain_text",
+							"content": "Mute",
+						},
+						"value": muteValue,
+					},
+				},
+			},
+		},
+	}
+	payload, err := json.Marshal(map[string]interface{}{
+		"msg_type": "interactive",
+		"card":     card,
+	})
+	if err != nil {
+		return err
+	}
+	resp, err := http.Post(webhook, "application/json", bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -217,6 +304,17 @@ func DecodeLarkCardCallback(body []byte) (LarkCallback, error) {
 			parsed, err := strconv.ParseUint(n, 10, 64)
 			if err == nil {
 				out.Tidx = parsed
+			}
+		}
+	}
+	if v, ok := raw.Event.Action.Value["height"]; ok {
+		switch n := v.(type) {
+		case float64:
+			out.Height = uint64(n)
+		case string:
+			parsed, err := strconv.ParseUint(n, 10, 64)
+			if err == nil {
+				out.Height = parsed
 			}
 		}
 	}

--- a/witness-service/util/lark_card_test.go
+++ b/witness-service/util/lark_card_test.go
@@ -106,3 +106,29 @@ func TestSendLarkStaleWarningCard_PostsMuteButton(t *testing.T) {
 		}
 	}
 }
+
+func TestSendLarkStaleWarningCard_MuteButtonRoutesByGuardKey(t *testing.T) {
+	// When the stale height belongs to a previous cashier, the body shows the
+	// owning cashier but the Mute button must route back to the posting guard.
+	var got []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := SendLarkStaleWarningCard(srv.URL, LarkStaleWarning{
+		Cashier: "0xPREVIOUS", GuardKey: "0xCURRENT", Height: 9, Nonce: "n",
+	}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	s := string(got)
+	// Mute button routes to the guard key.
+	if !strings.Contains(s, `"cashier":"0xCURRENT"`) {
+		t.Fatalf("mute button should route by GuardKey 0xCURRENT:\n%s", s)
+	}
+	// The owning cashier is shown in the card body.
+	if !strings.Contains(s, "0xPREVIOUS") {
+		t.Fatalf("card body should display owning cashier 0xPREVIOUS:\n%s", s)
+	}
+}

--- a/witness-service/util/lark_card_test.go
+++ b/witness-service/util/lark_card_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package util
+
+import (
+	"testing"
+)
+
+func TestDecodeLarkCardCallback_ParsesAction(t *testing.T) {
+	cases := []struct {
+		name       string
+		action     string
+		wantAction string
+	}{
+		{"approve button", "approve", "approve"},
+		{"reject button", "reject", "reject"},
+		{"missing action", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actionField := ""
+			if tc.action != "" {
+				actionField = `,"action":"` + tc.action + `"`
+			}
+			body := []byte(`{"event":{"operator":{"open_id":"ou_test"},"action":{"value":{"transferID":"0xdead","cashier":"c1","nonce":"n1"` + actionField + `},"form_value":{}}}}`)
+			cb, err := DecodeLarkCardCallback(body)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if cb.Action != tc.wantAction {
+				t.Fatalf("Action: got %q, want %q", cb.Action, tc.wantAction)
+			}
+			if cb.TransferID != "0xdead" {
+				t.Fatalf("TransferID: got %q", cb.TransferID)
+			}
+			if cb.OpenID != "ou_test" {
+				t.Fatalf("OpenID: got %q", cb.OpenID)
+			}
+			if cb.Nonce != "n1" {
+				t.Fatalf("Nonce: got %q", cb.Nonce)
+			}
+		})
+	}
+}

--- a/witness-service/util/lark_card_test.go
+++ b/witness-service/util/lark_card_test.go
@@ -7,6 +7,10 @@
 package util
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -44,5 +48,61 @@ func TestDecodeLarkCardCallback_ParsesAction(t *testing.T) {
 				t.Fatalf("Nonce: got %q", cb.Nonce)
 			}
 		})
+	}
+}
+
+func TestDecodeLarkCardCallback_ParsesMuteHeight(t *testing.T) {
+	cases := []struct {
+		name   string
+		height string // raw JSON value (quoted string or bare number)
+	}{
+		{"height as string", `"28401933"`},
+		{"height as number", `28401933`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{"event":{"operator":{"open_id":"ou_x"},"action":{"value":{"cashier":"c1","height":` +
+				tc.height + `,"nonce":"n2","action":"mute"}}}}`)
+			cb, err := DecodeLarkCardCallback(body)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if cb.Action != "mute" {
+				t.Fatalf("Action: got %q, want mute", cb.Action)
+			}
+			if cb.Height != 28401933 {
+				t.Fatalf("Height: got %d, want 28401933", cb.Height)
+			}
+			if cb.Cashier != "c1" {
+				t.Fatalf("Cashier: got %q", cb.Cashier)
+			}
+		})
+	}
+}
+
+func TestSendLarkStaleWarningCard_EmptyWebhook(t *testing.T) {
+	if err := SendLarkStaleWarningCard("", LarkStaleWarning{Height: 1}); err == nil {
+		t.Fatal("expected error for empty webhook")
+	}
+}
+
+func TestSendLarkStaleWarningCard_PostsMuteButton(t *testing.T) {
+	var got []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := SendLarkStaleWarningCard(srv.URL, LarkStaleWarning{
+		Cashier: "0xcash", Height: 42, Nonce: "n",
+	}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	s := string(got)
+	for _, want := range []string{`"msg_type":"interactive"`, `"action":"mute"`, `"height":"42"`, "Mute"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("card payload missing %q:\n%s", want, s)
+		}
 	}
 }

--- a/witness-service/witness/approval.go
+++ b/witness-service/witness/approval.go
@@ -288,41 +288,56 @@ func (g *ApprovalGuard) IsHeightMuted(height uint64) bool {
 	return ok
 }
 
+// staleAlertDedupWindow is how long a single stale height stays deduplicated
+// after a warning, so a stuck height does not spam the channel.
+const staleAlertDedupWindow = 30 * time.Minute
+
 // NotifyStaleFetchFailure posts a Lark card (with a Mute button) when the
-// witness cannot fetch a stale block's source data. Suppressed for muted
-// heights and deduplicated to one card per height per 30 minutes so a stuck
-// height does not spam the channel.
-func (g *ApprovalGuard) NotifyStaleFetchFailure(height uint64) {
+// witness cannot fetch a stale block's source data. `owner` is the cashier
+// contract the height belongs to (it may be a previous cashier), shown in the
+// card so the admin knows which contract is stuck; the Mute button still routes
+// back to this guard. Suppressed for muted heights and deduplicated per height.
+func (g *ApprovalGuard) NotifyStaleFetchFailure(owner string, height uint64) {
 	g.mu.Lock()
 	if _, muted := g.mutedHeights[height]; muted {
 		g.mu.Unlock()
 		return
 	}
-	if last, ok := g.staleAlert[height]; ok && time.Since(last) < 30*time.Minute {
+	// Prune expired dedup entries on the way in so the map cannot grow without
+	// bound (mirrors seenNonces); entries older than the window are useless.
+	now := time.Now()
+	cutoff := now.Add(-staleAlertDedupWindow)
+	for h, ts := range g.staleAlert {
+		if ts.Before(cutoff) {
+			delete(g.staleAlert, h)
+		}
+	}
+	if last, ok := g.staleAlert[height]; ok && now.Sub(last) < staleAlertDedupWindow {
 		g.mu.Unlock()
 		return
 	}
-	g.staleAlert[height] = time.Now()
+	g.staleAlert[height] = now
 	g.mu.Unlock()
 
 	nonce, err := randomNonce()
 	if err != nil {
 		g.larkAlerter(fmt.Sprintf(
-			"[witness:%s] cannot fetch stale block %d (source data deleted); failed to mint nonce: %v",
-			g.cashierKey, height, err,
+			"[witness:%s] cannot fetch stale block %d for cashier %s (source data deleted); failed to mint nonce: %v",
+			g.cashierKey, height, owner, err,
 		))
 		return
 	}
 	if err := util.SendLarkStaleWarningCard(g.larkCardWebhook, util.LarkStaleWarning{
-		Cashier: g.cashierKey,
-		Height:  height,
-		Nonce:   nonce,
+		Cashier:  owner,
+		GuardKey: g.cashierKey,
+		Height:   height,
+		Nonce:    nonce,
 	}); err != nil {
 		// Card delivery failed — fall back to the text channel so admins still
 		// know the witness is stuck on this height.
 		g.larkAlerter(fmt.Sprintf(
-			"[witness:%s] cannot fetch stale block %d (source data deleted); sign+submit manually then mute. (card send failed: %v)",
-			g.cashierKey, height, err,
+			"[witness:%s] cannot fetch stale block %d for cashier %s (source data deleted); sign+submit manually then mute. (card send failed: %v)",
+			g.cashierKey, height, owner, err,
 		))
 	}
 }

--- a/witness-service/witness/approval.go
+++ b/witness-service/witness/approval.go
@@ -1,0 +1,514 @@
+// Copyright (c) 2026 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package witness
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/iotexproject/ioTube/witness-service/util"
+)
+
+// Decision is returned by ApprovalGuard.Check for each transfer about to be
+// signed.
+type Decision int
+
+const (
+	// DecisionAllow lets the signer proceed.
+	DecisionAllow Decision = iota
+	// DecisionBlockWindow means signing this transfer would push the rolling
+	// window USD total over the configured limit, OR the cache is missing a
+	// fresh price needed to evaluate it; caller should skip and try again on
+	// the next tick.
+	DecisionBlockWindow
+	// DecisionRequireApproval means the transfer's single-tx USD value exceeds
+	// the configured per-tx limit and requires a Lark admin approval.
+	DecisionRequireApproval
+	// DecisionAlreadyAwaiting is a defensive case — the row was already flipped
+	// to `approval`; nothing to do.
+	DecisionAlreadyAwaiting
+)
+
+// TokenMeta carries the per-token information the guard needs to convert a
+// raw token amount into USD. Token is the lowercase hex (no `0x` prefix) of
+// the token's raw address bytes — this matches the form stored in the
+// transfer table's `token` column for both EVM and Solana recorders.
+type TokenMeta struct {
+	Token       string
+	CoinGeckoID string
+	Decimals    int
+}
+
+// PriceSource is the subset of util.PriceCache that the guard uses. Exposing
+// it as an interface keeps tests free of HTTP plumbing.
+type PriceSource interface {
+	Price(coingeckoID string) (*big.Float, bool)
+}
+
+// pendingApproval is in-memory state for one transfer awaiting an admin decision.
+type pendingApproval struct {
+	cashier   string
+	token     string
+	tidx      uint64
+	amount    *big.Int
+	nonce     string
+	createdAt time.Time
+	// decidedBy is the open_id of the first admin who approved or rejected.
+	// Once set, the decision is locked — no other admin (including the same
+	// one) may change it.
+	decidedBy string
+}
+
+// ApprovalGuard enforces a per-cashier rolling-window USD cap and a single
+// transaction admin-approval USD cap. A nil *ApprovalGuard is a valid value that
+// disables all checks — callers must guard with `if g != nil`.
+type ApprovalGuard struct {
+	cashierKey       string
+	windowDuration   time.Duration
+	windowUsdLimit   *big.Float // zero or nil ⇒ disabled
+	singleTxUsdLimit *big.Float // zero or nil ⇒ disabled
+	tokens           map[string]TokenMeta
+	prices           PriceSource
+	recorder         AbstractRecorder
+	larkCardWebhook  string
+	explorerTxURL    string     // base URL for source-chain tx explorer; hash appended directly
+	larkAlerter      func(string) // defaults to util.Alert
+
+	mu         sync.Mutex
+	pending    map[string]*pendingApproval // key = transferID hex (without 0x)
+	seenNonces map[string]time.Time        // header nonces seen recently
+
+	windowAlert     time.Time // last time we emitted a window-block alert
+	stalePriceAlert time.Time // last time we emitted a stale-price alert
+}
+
+// NewApprovalGuard returns a guard for one cashier. windowUsdLimit /
+// singleTxUsdLimit may be nil (or zero) to disable that dimension while
+// leaving the other active. windowDuration must be > 0. `tokens` is the set
+// of source-chain tokens the cashier may sign for — any transfer whose token
+// is not in the map causes Check to error out (mis-configuration).
+func NewApprovalGuard(
+	cashierKey string,
+	windowDuration time.Duration,
+	windowUsdLimit *big.Float,
+	singleTxUsdLimit *big.Float,
+	tokens []TokenMeta,
+	prices PriceSource,
+	recorder AbstractRecorder,
+	larkCardWebhook string,
+	explorerTxURL string,
+) *ApprovalGuard {
+	if windowDuration <= 0 {
+		windowDuration = 24 * time.Hour
+	}
+	tokenMap := make(map[string]TokenMeta, len(tokens))
+	for _, tk := range tokens {
+		key := strings.ToLower(strings.TrimPrefix(tk.Token, "0x"))
+		tokenMap[key] = TokenMeta{
+			Token:       key,
+			CoinGeckoID: strings.ToLower(strings.TrimSpace(tk.CoinGeckoID)),
+			Decimals:    tk.Decimals,
+		}
+	}
+	return &ApprovalGuard{
+		cashierKey:       cashierKey,
+		windowDuration:   windowDuration,
+		windowUsdLimit:   normalizeUsdLimit(windowUsdLimit),
+		singleTxUsdLimit: normalizeUsdLimit(singleTxUsdLimit),
+		tokens:           tokenMap,
+		prices:           prices,
+		recorder:         recorder,
+		larkCardWebhook:  larkCardWebhook,
+		explorerTxURL:    explorerTxURL,
+		larkAlerter:      util.Alert,
+		pending:          make(map[string]*pendingApproval),
+		seenNonces:       make(map[string]time.Time),
+	}
+}
+
+func normalizeUsdLimit(v *big.Float) *big.Float {
+	if v == nil || v.Sign() == 0 {
+		return nil
+	}
+	return new(big.Float).Copy(v)
+}
+
+// CashierKey returns the cashier identifier this guard is bound to. Used by
+// the HTTP callback server to route incoming Lark callbacks.
+func (g *ApprovalGuard) CashierKey() string {
+	return g.cashierKey
+}
+
+// normalizeTokenKey converts an AbstractTransfer's Token() into the same form
+// used by the tokens map and by SignedAmountSince row keys.
+func normalizeTokenKey(addr util.Address) string {
+	return strings.ToLower(hex.EncodeToString(addr.Bytes()))
+}
+
+// amountToUSD converts `amount` in token base units to a *big.Float USD value
+// given the token's `decimals` and current `price`. Returns a freshly
+// allocated *big.Float — caller may mutate.
+func amountToUSD(amount *big.Int, decimals int, price *big.Float) *big.Float {
+	if amount == nil || price == nil {
+		return new(big.Float)
+	}
+	amtF := new(big.Float).SetInt(amount)
+	if decimals > 0 {
+		divisor := new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil))
+		amtF.Quo(amtF, divisor)
+	}
+	return new(big.Float).Mul(amtF, price)
+}
+
+// Check evaluates a candidate transfer against the configured USD limits.
+// Returns DecisionAllow when neither limit blocks signing.
+func (g *ApprovalGuard) Check(t AbstractTransfer) (Decision, error) {
+	if g.windowUsdLimit == nil && g.singleTxUsdLimit == nil {
+		return DecisionAllow, nil
+	}
+
+	amt := t.Amount()
+	if amt == nil || amt.Sign() == 0 {
+		return DecisionAllow, nil
+	}
+
+	tokenKey := normalizeTokenKey(t.Token())
+	meta, ok := g.tokens[tokenKey]
+	if !ok {
+		return DecisionAllow, fmt.Errorf("approval guard: no token metadata for %s on cashier %s", tokenKey, g.cashierKey)
+	}
+	if meta.CoinGeckoID == "" {
+		return DecisionAllow, fmt.Errorf("approval guard: token %s on cashier %s is missing coingeckoID", tokenKey, g.cashierKey)
+	}
+
+	price, ok := g.prices.Price(meta.CoinGeckoID)
+	if !ok {
+		g.notifyStalePrice(meta.CoinGeckoID, tokenKey)
+		return DecisionBlockWindow, nil
+	}
+	txUSD := amountToUSD(amt, meta.Decimals, price)
+
+	// Single-tx limit first — if a transfer alone is too large we'd rather
+	// route it through the approval flow than silently pause the queue.
+	if g.singleTxUsdLimit != nil && txUSD.Cmp(g.singleTxUsdLimit) > 0 {
+		if t.Status() == TransferAwaitingApproval {
+			return DecisionAlreadyAwaiting, nil
+		}
+		return DecisionRequireApproval, nil
+	}
+
+	if g.windowUsdLimit == nil {
+		return DecisionAllow, nil
+	}
+	since := time.Now().Add(-g.windowDuration)
+	totals, err := g.recorder.SignedAmountSince(g.cashierKey, since)
+	if err != nil {
+		return DecisionAllow, fmt.Errorf("approval guard: failed to load window totals: %w", err)
+	}
+	windowUSD := new(big.Float)
+	for tk, sum := range totals {
+		tm, ok := g.tokens[tk]
+		if !ok || tm.CoinGeckoID == "" {
+			// Historic row for a token we no longer track; skip rather than
+			// fail closed, because the alternative would brick signing after
+			// every config change that removes a token.
+			continue
+		}
+		p, ok := g.prices.Price(tm.CoinGeckoID)
+		if !ok {
+			g.notifyStalePrice(tm.CoinGeckoID, tk)
+			return DecisionBlockWindow, nil
+		}
+		windowUSD.Add(windowUSD, amountToUSD(sum, tm.Decimals, p))
+	}
+	projected := new(big.Float).Add(windowUSD, txUSD)
+	if projected.Cmp(g.windowUsdLimit) > 0 {
+		return DecisionBlockWindow, nil
+	}
+	return DecisionAllow, nil
+}
+
+// NotifyWindowBlocked emits a Lark text alert when signing is paused due to the
+// rolling-window limit. Internally deduplicated to one alert per 10 minutes so
+// a stuck queue does not spam the channel.
+func (g *ApprovalGuard) NotifyWindowBlocked(t AbstractTransfer) {
+	g.mu.Lock()
+	if time.Since(g.windowAlert) < 10*time.Minute {
+		g.mu.Unlock()
+		return
+	}
+	g.windowAlert = time.Now()
+	g.mu.Unlock()
+	g.larkAlerter(fmt.Sprintf(
+		"[witness:%s] rolling-window USD limit reached; pausing signing. Pending transfer %s amount=%s",
+		g.cashierKey, t.Cashier(), t.Amount().String(),
+	))
+}
+
+// notifyStalePrice emits a deduplicated Lark alert when the price feed is
+// missing or stale for a token we need. The dedup window matches the rolling
+// window alert (10 minutes).
+func (g *ApprovalGuard) notifyStalePrice(coingeckoID, tokenKey string) {
+	g.mu.Lock()
+	if time.Since(g.stalePriceAlert) < 10*time.Minute {
+		g.mu.Unlock()
+		return
+	}
+	g.stalePriceAlert = time.Now()
+	g.mu.Unlock()
+	g.larkAlerter(fmt.Sprintf(
+		"[witness:%s] price feed missing or stale for coingeckoID=%s token=%s; pausing signing until refresh",
+		g.cashierKey, coingeckoID, tokenKey,
+	))
+}
+
+// formatUSD returns a human-readable USD string for the transfer amount
+// (e.g. "$61,234.56"). Returns "" when the price or token metadata is unavailable.
+func (g *ApprovalGuard) formatUSD(t AbstractTransfer) string {
+	tokenKey := normalizeTokenKey(t.Token())
+	meta, ok := g.tokens[tokenKey]
+	if !ok || meta.CoinGeckoID == "" {
+		return ""
+	}
+	price, ok := g.prices.Price(meta.CoinGeckoID)
+	if !ok {
+		return ""
+	}
+	usd := amountToUSD(t.Amount(), meta.Decimals, price)
+	f, _ := usd.Float64()
+	return fmt.Sprintf("$%s", formatComma(f))
+}
+
+// formatComma formats a float64 as a comma-separated dollar string with 2 d.p.
+func formatComma(v float64) string {
+	// Format with 2 decimal places, then insert thousand separators.
+	s := fmt.Sprintf("%.2f", v)
+	// Find the decimal point.
+	dot := strings.Index(s, ".")
+	intPart := s[:dot]
+	fracPart := s[dot:] // ".xx"
+	// Insert commas every 3 digits from the right of the integer part.
+	out := make([]byte, 0, len(intPart)+len(intPart)/3+len(fracPart))
+	for i, c := range intPart {
+		if i > 0 && (len(intPart)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, byte(c))
+	}
+	return string(out) + fracPart
+}
+
+// RequestApproval flips the transfer to TransferAwaitingApproval, records
+// pending state, and posts a Lark interactive card with Approve and Reject
+// buttons so an admin can decide.
+func (g *ApprovalGuard) RequestApproval(t AbstractTransfer) error {
+	tid := strings.TrimPrefix(hexlower(t.ID()), "0x")
+
+	g.mu.Lock()
+	if _, exists := g.pending[tid]; exists {
+		g.mu.Unlock()
+		return nil // already requested, awaiting admin decision
+	}
+	nonce, err := randomNonce()
+	if err != nil {
+		g.mu.Unlock()
+		return err
+	}
+	g.pending[tid] = &pendingApproval{
+		cashier:   g.cashierKey,
+		token:     t.Token().String(),
+		tidx:      t.Index().Uint64(),
+		amount:    new(big.Int).Set(t.Amount()),
+		nonce:     nonce,
+		createdAt: time.Now(),
+	}
+	g.mu.Unlock()
+
+	if err := g.recorder.MarkTransferAwaitingApproval(t); err != nil {
+		// rollback in-memory state so retry works
+		g.mu.Lock()
+		delete(g.pending, tid)
+		g.mu.Unlock()
+		return err
+	}
+
+	txHash := "0x" + tid
+	card := util.LarkApprovalRequest{
+		TransferID: txHash,
+		Cashier:    g.cashierKey,
+		Token:      t.Token().String(),
+		Recipient:  t.Recipient().String(),
+		Amount:     t.Amount().String(),
+		AmountUSD:  g.formatUSD(t),
+		TxHash:     txHash,
+		TxHashURL:  g.explorerTxURL + txHash,
+		Nonce:      nonce,
+	}
+	if err := util.SendLarkApprovalCard(g.larkCardWebhook, card); err != nil {
+		// Card delivery failed — keep DB row in approval; alert via text channel so
+		// admins still know to investigate.
+		g.larkAlerter(fmt.Sprintf(
+			"[witness:%s] failed to send Lark approval card for transfer 0x%s: %v",
+			g.cashierKey, tid, err,
+		))
+		return nil
+	}
+	return nil
+}
+
+// resolveTarget figures out which DB row this callback decides. When an
+// in-memory pending entry is present, it locks the decision slot (first
+// responder wins) and returns (cashier, token, tidx) from that entry plus
+// locked=true. When the entry is missing — which happens after a witness
+// restart, since pending is in-memory only — it falls back to the values
+// embedded in the callback payload itself, returning locked=false. Replay
+// protection in the fallback path is bounded by the DB filter
+// `WHERE status='approval'`: only one UPDATE can transition the row out of
+// that state.
+//
+// cb.Cashier is NOT trusted for the WHERE clause — only for routing to this
+// guard. We use g.cashierKey instead so a tampered cashier field cannot
+// cross-target another cashier's rows.
+func (g *ApprovalGuard) resolveTarget(cb util.LarkCallback) (cashier, token string, tidx uint64, locked bool, err error) {
+	tid := strings.TrimPrefix(strings.ToLower(cb.TransferID), "0x")
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if pending, ok := g.pending[tid]; ok {
+		if pending.nonce != cb.Nonce {
+			return "", "", 0, false, fmt.Errorf("nonce mismatch for transfer %s", tid)
+		}
+		if pending.decidedBy != "" {
+			return "", "", 0, false, fmt.Errorf("transfer %s already decided by %s", tid, pending.decidedBy)
+		}
+		pending.decidedBy = cb.OpenID
+		return pending.cashier, pending.token, pending.tidx, true, nil
+	}
+
+	if cb.Token == "" || cb.Tidx == 0 {
+		return "", "", 0, false, fmt.Errorf("no pending approval for transfer %s and callback payload missing token/tidx", tid)
+	}
+	return g.cashierKey, cb.Token, cb.Tidx, false, nil
+}
+
+// releasePending clears the decision lock on the in-memory pending entry so a
+// retry can succeed. No-op when the entry is already gone.
+func (g *ApprovalGuard) releasePending(tid string) {
+	g.mu.Lock()
+	if p, exists := g.pending[tid]; exists {
+		p.decidedBy = ""
+	}
+	g.mu.Unlock()
+}
+
+// Approve is called by the HTTP callback handler when a Lark user approves a
+// transfer. Locks the decision when in-memory state is present (first
+// responder wins); after a witness restart, falls back to the callback
+// payload and lets the DB UPDATE atomicity enforce one-shot semantics.
+func (g *ApprovalGuard) Approve(cb util.LarkCallback) (bool, error) {
+	tid := strings.TrimPrefix(strings.ToLower(cb.TransferID), "0x")
+
+	cashier, token, tidx, locked, err := g.resolveTarget(cb)
+	if err != nil {
+		return false, err
+	}
+
+	ok, err := g.recorder.ApproveTransferToReady(cashier, token, tidx)
+	if err != nil {
+		if locked {
+			g.releasePending(tid)
+		}
+		return false, err
+	}
+
+	if locked {
+		g.mu.Lock()
+		delete(g.pending, tid)
+		g.mu.Unlock()
+	}
+
+	if ok {
+		g.larkAlerter(fmt.Sprintf(
+			"[witness:%s] transfer 0x%s approved by open_id=%s; resuming signing",
+			g.cashierKey, tid, cb.OpenID,
+		))
+	}
+	return ok, nil
+}
+
+// Reject is called by the HTTP callback handler when a Lark user rejects a
+// transfer. Same locked/fallback split as Approve.
+func (g *ApprovalGuard) Reject(cb util.LarkCallback) (bool, error) {
+	tid := strings.TrimPrefix(strings.ToLower(cb.TransferID), "0x")
+
+	cashier, token, tidx, locked, err := g.resolveTarget(cb)
+	if err != nil {
+		return false, err
+	}
+
+	ok, err := g.recorder.RejectTransfer(cashier, token, tidx)
+	if err != nil {
+		if locked {
+			g.releasePending(tid)
+		}
+		return false, err
+	}
+
+	if locked {
+		g.mu.Lock()
+		delete(g.pending, tid)
+		g.mu.Unlock()
+	}
+
+	if ok {
+		g.larkAlerter(fmt.Sprintf(
+			"[witness:%s] transfer 0x%s rejected by open_id=%s",
+			g.cashierKey, tid, cb.OpenID,
+		))
+	}
+	return ok, nil
+}
+
+// SeenNonce returns true if the Lark header nonce was already accepted within
+// the dedup window. Acceptable nonces are inserted on first sight. Old entries
+// are pruned at insertion time.
+func (g *ApprovalGuard) SeenNonce(nonce string) bool {
+	if nonce == "" {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	cutoff := time.Now().Add(-10 * time.Minute)
+	for k, ts := range g.seenNonces {
+		if ts.Before(cutoff) {
+			delete(g.seenNonces, k)
+		}
+	}
+	if _, dup := g.seenNonces[nonce]; dup {
+		return true
+	}
+	g.seenNonces[nonce] = time.Now()
+	return false
+}
+
+func hexlower(b []byte) string {
+	return hex.EncodeToString(b)
+}
+
+func randomNonce() (string, error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}

--- a/witness-service/witness/approval.go
+++ b/witness-service/witness/approval.go
@@ -423,7 +423,7 @@ func (g *ApprovalGuard) Approve(cb util.LarkCallback) (bool, error) {
 		return false, err
 	}
 
-	ok, err := g.recorder.ApproveTransferToReady(cashier, token, tidx)
+	ok, err := g.recorder.ApproveTransfer(cashier, token, tidx)
 	if err != nil {
 		if locked {
 			g.releasePending(tid)

--- a/witness-service/witness/approval.go
+++ b/witness-service/witness/approval.go
@@ -89,6 +89,13 @@ type ApprovalGuard struct {
 
 	windowAlert     time.Time // last time we emitted a window-block alert
 	stalePriceAlert time.Time // last time we emitted a stale-price alert
+
+	// mutedHeights are stale block heights an admin has chosen to ignore (the
+	// source data is gone). ProcessStales skips them; in-memory only, so the
+	// set is cleared on restart.
+	mutedHeights map[uint64]struct{}
+	// staleAlert dedups the per-height "can't fetch" warning.
+	staleAlert map[uint64]time.Time
 }
 
 // NewApprovalGuard returns a guard for one cashier. windowUsdLimit /
@@ -132,6 +139,8 @@ func NewApprovalGuard(
 		larkAlerter:      util.Alert,
 		pending:          make(map[string]*pendingApproval),
 		seenNonces:       make(map[string]time.Time),
+		mutedHeights:     make(map[uint64]struct{}),
+		staleAlert:       make(map[uint64]time.Time),
 	}
 }
 
@@ -269,6 +278,73 @@ func (g *ApprovalGuard) notifyStalePrice(coingeckoID, tokenKey string) {
 		"[witness:%s] price feed missing or stale for coingeckoID=%s token=%s; pausing signing until refresh",
 		g.cashierKey, coingeckoID, tokenKey,
 	))
+}
+
+// IsHeightMuted reports whether an admin has muted this stale block height.
+func (g *ApprovalGuard) IsHeightMuted(height uint64) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, ok := g.mutedHeights[height]
+	return ok
+}
+
+// NotifyStaleFetchFailure posts a Lark card (with a Mute button) when the
+// witness cannot fetch a stale block's source data. Suppressed for muted
+// heights and deduplicated to one card per height per 30 minutes so a stuck
+// height does not spam the channel.
+func (g *ApprovalGuard) NotifyStaleFetchFailure(height uint64) {
+	g.mu.Lock()
+	if _, muted := g.mutedHeights[height]; muted {
+		g.mu.Unlock()
+		return
+	}
+	if last, ok := g.staleAlert[height]; ok && time.Since(last) < 30*time.Minute {
+		g.mu.Unlock()
+		return
+	}
+	g.staleAlert[height] = time.Now()
+	g.mu.Unlock()
+
+	nonce, err := randomNonce()
+	if err != nil {
+		g.larkAlerter(fmt.Sprintf(
+			"[witness:%s] cannot fetch stale block %d (source data deleted); failed to mint nonce: %v",
+			g.cashierKey, height, err,
+		))
+		return
+	}
+	if err := util.SendLarkStaleWarningCard(g.larkCardWebhook, util.LarkStaleWarning{
+		Cashier: g.cashierKey,
+		Height:  height,
+		Nonce:   nonce,
+	}); err != nil {
+		// Card delivery failed — fall back to the text channel so admins still
+		// know the witness is stuck on this height.
+		g.larkAlerter(fmt.Sprintf(
+			"[witness:%s] cannot fetch stale block %d (source data deleted); sign+submit manually then mute. (card send failed: %v)",
+			g.cashierKey, height, err,
+		))
+	}
+}
+
+// Mute records that an admin has chosen to ignore the stale block height so the
+// witness stops retrying/alerting on it. Returns (false, nil) when the height
+// was already muted (idempotent duplicate callback).
+func (g *ApprovalGuard) Mute(cb util.LarkCallback) (bool, error) {
+	g.mu.Lock()
+	if _, exists := g.mutedHeights[cb.Height]; exists {
+		g.mu.Unlock()
+		return false, nil
+	}
+	g.mutedHeights[cb.Height] = struct{}{}
+	delete(g.staleAlert, cb.Height)
+	g.mu.Unlock()
+
+	g.larkAlerter(fmt.Sprintf(
+		"[witness:%s] stale block %d muted by open_id=%s; witness will stop retrying it",
+		g.cashierKey, cb.Height, cb.OpenID,
+	))
+	return true, nil
 }
 
 // formatUSD returns a human-readable USD string for the transfer amount

--- a/witness-service/witness/approval_server.go
+++ b/witness-service/witness/approval_server.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package witness
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/iotexproject/ioTube/witness-service/util"
+)
+
+// ApprovalServer exposes a single POST /lark/callback endpoint that authorizes
+// previously-paused transfers. Multiple cashiers share one server; the
+// embedded `cashier` field in the Lark card's action.value routes to the right
+// ApprovalGuard.
+type ApprovalServer struct {
+	listenAddr    string
+	signingSecret string
+	guards        map[string]*ApprovalGuard
+
+	mu          sync.Mutex
+	failuresPer map[string]int // open_id → consecutive failed action attempts
+}
+
+// NewApprovalServer returns a server bound to the given listen address (e.g.
+// ":9082"). signingSecret is the Lark workspace's webhook verification
+// secret; pass "" to disable signature checking (insecure — only for local
+// testing). guards keys MUST match the `cashier` value embedded in each card.
+func NewApprovalServer(listenAddr, signingSecret string, guards map[string]*ApprovalGuard) *ApprovalServer {
+	return &ApprovalServer{
+		listenAddr:    listenAddr,
+		signingSecret: signingSecret,
+		guards:        guards,
+		failuresPer:   make(map[string]int),
+	}
+}
+
+// Start binds the listen address and launches the HTTP server in a goroutine.
+// It returns an error if the port cannot be bound so the caller can fail fast.
+func (s *ApprovalServer) Start() error {
+	if s == nil || s.listenAddr == "" {
+		return nil
+	}
+	ln, err := net.Listen("tcp", s.listenAddr)
+	if err != nil {
+		return err
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/lark/callback", s.handleCallback)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	})
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		log.Printf("approval server listening on %s\n", s.listenAddr)
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			log.Printf("approval server stopped: %v\n", err)
+		}
+	}()
+	return nil
+}
+
+func (s *ApprovalServer) handleCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+
+	timestamp := r.Header.Get("X-Lark-Request-Timestamp")
+	nonce := r.Header.Get("X-Lark-Request-Nonce")
+	gotSig := r.Header.Get("X-Lark-Signature")
+
+	// Lark URL verification handshake: POST {"type":"url_verification","challenge":"...","token":"..."}.
+	// Reply with the challenge before any signature check so the workspace can
+	// register the URL.
+	var probe struct {
+		Type      string `json:"type"`
+		Challenge string `json:"challenge"`
+	}
+	if json.Unmarshal(body, &probe) == nil && probe.Type == "url_verification" {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"challenge": probe.Challenge})
+		return
+	}
+
+	if s.signingSecret != "" {
+		if !util.VerifyLarkCallbackSignature(s.signingSecret, timestamp, nonce, body, gotSig) {
+			log.Printf("approval server: signature mismatch from %s\n", r.RemoteAddr)
+			http.Error(w, "signature mismatch", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	// Decode + replay protection
+	cb, err := util.DecodeLarkCardCallback(body)
+	if err != nil {
+		http.Error(w, "bad payload", http.StatusBadRequest)
+		return
+	}
+	if cb.Timestamp != 0 && !util.FreshTimestamp(cb.Timestamp, time.Now(), 5*time.Minute) {
+		http.Error(w, "stale request", http.StatusBadRequest)
+		return
+	}
+	guard, ok := s.guards[cb.Cashier]
+	if !ok {
+		http.Error(w, "unknown cashier", http.StatusNotFound)
+		return
+	}
+	if guard.SeenNonce(nonce) {
+		http.Error(w, "duplicate", http.StatusConflict)
+		return
+	}
+
+	var acted bool
+	var actErr error
+	switch cb.Action {
+	case "approve":
+		acted, actErr = guard.Approve(cb)
+	case "reject":
+		acted, actErr = guard.Reject(cb)
+	default:
+		http.Error(w, "unknown action", http.StatusBadRequest)
+		return
+	}
+	if actErr != nil {
+		s.recordFailure(cb.OpenID)
+		respondToast(w, false, fmt.Sprintf("action failed: %v", actErr))
+		return
+	}
+	s.clearFailures(cb.OpenID)
+	if !acted {
+		// Row was not in approval state — already handled by another admin.
+		respondToast(w, false, "transfer already decided (handled by another admin?)")
+		return
+	}
+	if cb.Action == "reject" {
+		respondToast(w, true, "transfer rejected")
+	} else {
+		respondToast(w, true, "transfer approved")
+	}
+}
+
+func (s *ApprovalServer) recordFailure(openID string) {
+	if openID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failuresPer[openID]++
+	if s.failuresPer[openID] >= 3 {
+		util.Alert(fmt.Sprintf("[witness:approval] open_id=%s has %d consecutive failed approvals",
+			openID, s.failuresPer[openID]))
+	}
+}
+
+func (s *ApprovalServer) clearFailures(openID string) {
+	if openID == "" {
+		return
+	}
+	s.mu.Lock()
+	delete(s.failuresPer, openID)
+	s.mu.Unlock()
+}
+
+func respondToast(w http.ResponseWriter, ok bool, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	level := "info"
+	if !ok {
+		level = "error"
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"toast": map[string]interface{}{
+			"type":    level,
+			"content": msg,
+		},
+	})
+}

--- a/witness-service/witness/approval_server.go
+++ b/witness-service/witness/approval_server.go
@@ -137,6 +137,8 @@ func (s *ApprovalServer) handleCallback(w http.ResponseWriter, r *http.Request) 
 		acted, actErr = guard.Approve(cb)
 	case "reject":
 		acted, actErr = guard.Reject(cb)
+	case "mute":
+		acted, actErr = guard.Mute(cb)
 	default:
 		http.Error(w, "unknown action", http.StatusBadRequest)
 		return
@@ -147,15 +149,26 @@ func (s *ApprovalServer) handleCallback(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	s.clearFailures(cb.OpenID)
-	if !acted {
-		// Row was not in approval state — already handled by another admin.
-		respondToast(w, false, "transfer already decided (handled by another admin?)")
-		return
-	}
-	if cb.Action == "reject" {
-		respondToast(w, true, "transfer rejected")
-	} else {
-		respondToast(w, true, "transfer approved")
+	switch cb.Action {
+	case "mute":
+		if !acted {
+			respondToast(w, true, "height already muted")
+		} else {
+			respondToast(w, true, "height muted")
+		}
+	case "reject":
+		if !acted {
+			respondToast(w, false, "transfer already decided (handled by another admin?)")
+		} else {
+			respondToast(w, true, "transfer rejected")
+		}
+	default:
+		if !acted {
+			// Row was not in approval state — already handled by another admin.
+			respondToast(w, false, "transfer already decided (handled by another admin?)")
+		} else {
+			respondToast(w, true, "transfer approved")
+		}
 	}
 }
 

--- a/witness-service/witness/approval_server_test.go
+++ b/witness-service/witness/approval_server_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package witness
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestApprovalServer_MuteCallback drives a Lark "mute" card callback end-to-end
+// through the HTTP handler and asserts the height is muted on the routed guard.
+func TestApprovalServer_MuteCallback(t *testing.T) {
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("c", time.Hour, nil, nil, nil, newFakePrices(nil), rec, "", "")
+	g.larkAlerter = func(string) {}
+	// signingSecret "" disables signature verification for the test.
+	s := NewApprovalServer(":0", "", map[string]*ApprovalGuard{"c": g})
+
+	body := `{"event":{"operator":{"open_id":"ou_a"},"action":{"value":{"cashier":"c","height":"77","nonce":"cn","action":"mute"}}}}`
+	req := httptest.NewRequest(http.MethodPost, "/lark/callback", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleCallback(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if !g.IsHeightMuted(77) {
+		t.Fatal("height 77 should be muted after the callback")
+	}
+	if !strings.Contains(w.Body.String(), "muted") {
+		t.Fatalf("expected a 'muted' toast, got %s", w.Body.String())
+	}
+
+	// A second identical callback is idempotent — still muted, no error toast.
+	req2 := httptest.NewRequest(http.MethodPost, "/lark/callback", strings.NewReader(body))
+	w2 := httptest.NewRecorder()
+	s.handleCallback(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second callback status=%d body=%s", w2.Code, w2.Body.String())
+	}
+	if !g.IsHeightMuted(77) {
+		t.Fatal("height 77 should remain muted")
+	}
+}

--- a/witness-service/witness/approval_test.go
+++ b/witness-service/witness/approval_test.go
@@ -1,0 +1,931 @@
+// Copyright (c) 2026 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package witness
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/iotexproject/ioTube/witness-service/grpc/types"
+	"github.com/iotexproject/ioTube/witness-service/util"
+)
+
+func computeLarkSig(secret, ts, nonce string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts))
+	mac.Write([]byte("\n"))
+	mac.Write([]byte(nonce))
+	mac.Write([]byte("\n"))
+	mac.Write(body)
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// --- test doubles -----------------------------------------------------------
+
+type fakeRecorder struct {
+	mu                 sync.Mutex
+	totals             map[string]*big.Int
+	submittable        []AbstractTransfer // returned by TransfersToSubmit; nil → empty
+	awaitingCalls      int
+	approveCalls       int
+	rejectCalls        int
+	approveReturnsBool bool
+}
+
+// newFakeRecorder constructs a recorder pre-loaded with per-token totals. The
+// keys must be the lowercase hex of the token's raw bytes (no `0x`) — the same
+// form the production recorders return.
+func newFakeRecorder(totals map[string]int64) *fakeRecorder {
+	out := make(map[string]*big.Int, len(totals))
+	for k, v := range totals {
+		out[strings.ToLower(strings.TrimPrefix(k, "0x"))] = big.NewInt(v)
+	}
+	return &fakeRecorder{
+		totals:             out,
+		approveReturnsBool: true,
+	}
+}
+
+func (f *fakeRecorder) Start(context.Context) error { return nil }
+func (f *fakeRecorder) Stop(context.Context) error  { return nil }
+func (f *fakeRecorder) AddTransfer(AbstractTransfer, TransferStatus) error {
+	return nil
+}
+func (f *fakeRecorder) UpsertTransfer(AbstractTransfer) error           { return nil }
+func (f *fakeRecorder) TipHeight(string) (uint64, error)                { return 0, nil }
+func (f *fakeRecorder) UpdateSyncHeight(string, uint64) error           { return nil }
+func (f *fakeRecorder) Transfer(common.Hash) (AbstractTransfer, error)  { return nil, nil }
+func (f *fakeRecorder) UnsettledTransfers() ([]string, error)           { return nil, nil }
+func (f *fakeRecorder) TransfersToSubmit(string) ([]AbstractTransfer, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.submittable, nil
+}
+func (f *fakeRecorder) TransfersToSettle(string) ([]AbstractTransfer, error) {
+	return nil, nil
+}
+func (f *fakeRecorder) SettleTransfer(AbstractTransfer) error        { return nil }
+func (f *fakeRecorder) ConfirmTransfer(AbstractTransfer) error       { return nil }
+func (f *fakeRecorder) MarkTransferAsPending(AbstractTransfer) error { return nil }
+func (f *fakeRecorder) MarkTransferAwaitingApproval(AbstractTransfer) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.awaitingCalls++
+	return nil
+}
+func (f *fakeRecorder) ApproveTransferToReady(string, string, uint64) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.approveCalls++
+	return f.approveReturnsBool, nil
+}
+func (f *fakeRecorder) RejectTransfer(string, string, uint64) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rejectCalls++
+	return true, nil
+}
+func (f *fakeRecorder) SignedAmountSince(string, time.Time) (map[string]*big.Int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]*big.Int, len(f.totals))
+	for k, v := range f.totals {
+		out[k] = new(big.Int).Set(v)
+	}
+	return out, nil
+}
+
+// fakePrices satisfies PriceSource for tests. Setting an id to nil makes it
+// return ok=false, simulating a missing / stale price.
+type fakePrices struct {
+	mu sync.Mutex
+	p  map[string]*big.Float
+}
+
+func newFakePrices(prices map[string]float64) *fakePrices {
+	out := make(map[string]*big.Float, len(prices))
+	for k, v := range prices {
+		out[strings.ToLower(k)] = big.NewFloat(v)
+	}
+	return &fakePrices{p: out}
+}
+
+func (f *fakePrices) Price(id string) (*big.Float, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.p[strings.ToLower(id)]
+	if !ok || v == nil {
+		return nil, false
+	}
+	return new(big.Float).Copy(v), true
+}
+
+// fakeTransfer implements AbstractTransfer enough for guard tests.
+type fakeTransfer struct {
+	cashier common.Address
+	token   common.Address
+	tidx    uint64
+	amount  *big.Int
+	id      common.Hash
+	status  TransferStatus
+}
+
+func (f *fakeTransfer) Cashier() util.Address  { return util.ETHAddressToAddress(f.cashier) }
+func (f *fakeTransfer) Token() util.Address    { return util.ETHAddressToAddress(f.token) }
+func (f *fakeTransfer) CoToken() util.Address  { return util.ETHAddressToAddress(f.token) }
+func (f *fakeTransfer) Index() *big.Int        { return new(big.Int).SetUint64(f.tidx) }
+func (f *fakeTransfer) Sender() util.Address   { return util.ETHAddressToAddress(common.Address{}) }
+func (f *fakeTransfer) Recipient() util.Address {
+	return util.ETHAddressToAddress(common.Address{})
+}
+func (f *fakeTransfer) Payload() []byte        { return nil }
+func (f *fakeTransfer) Amount() *big.Int       { return new(big.Int).Set(f.amount) }
+func (f *fakeTransfer) ID() []byte             { return f.id[:] }
+func (f *fakeTransfer) SetID(h common.Hash)    { f.id = h }
+func (f *fakeTransfer) Status() TransferStatus { return f.status }
+func (f *fakeTransfer) BlockHeight() uint64    { return 0 }
+func (f *fakeTransfer) ToTypesTransfer() *types.Transfer {
+	return &types.Transfer{}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// tokenKeyFor returns the lowercase hex (no prefix) of an EVM address — the
+// same form the recorders use as map keys.
+func tokenKeyFor(a common.Address) string {
+	return strings.ToLower(hex.EncodeToString(a.Bytes()))
+}
+
+// usd builds a *big.Float from an int dollar amount.
+func usd(v int64) *big.Float { return big.NewFloat(float64(v)) }
+
+// --- tests -----------------------------------------------------------------
+
+func TestApprovalGuard_AllowWhenUnderLimits(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x1111")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, usd(1_000_000), usd(1_000_000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+	// 1 WETH at $100 = $100, under any limit
+	tx := &fakeTransfer{
+		amount: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), // 1e18 = 1 WETH
+		token:  tokenAddr,
+		status: TransferReady,
+	}
+	d, err := g.Check(tx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if d != DecisionAllow {
+		t.Fatalf("expected allow, got %v", d)
+	}
+}
+
+func TestApprovalGuard_BlockWindow_USD(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x2222")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	// 9.5 WETH already signed = $950 in window
+	preTotal := new(big.Int).Mul(big.NewInt(95), new(big.Int).Exp(big.NewInt(10), big.NewInt(17), nil))
+	rec := newFakeRecorder(map[string]int64{})
+	rec.totals[tokenKeyFor(tokenAddr)] = preTotal
+	// USD window limit $1000, single-tx $5000 (so single-tx doesn't trip first).
+	g := NewApprovalGuard("c", time.Hour, usd(1000), usd(5000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+	// 1 WETH = $100, pushes total to $1050 > $1000 → block window
+	tx := &fakeTransfer{
+		amount: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+		token:  tokenAddr,
+		status: TransferReady,
+	}
+	d, err := g.Check(tx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if d != DecisionBlockWindow {
+		t.Fatalf("expected block-window, got %v", d)
+	}
+}
+
+func TestApprovalGuard_RequireApproval_USD(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x3333")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "wbtc", Decimals: 8}}
+	prices := newFakePrices(map[string]float64{"wbtc": 60_000})
+	rec := newFakeRecorder(map[string]int64{})
+	// Window $1M (loose), single-tx $50k.
+	g := NewApprovalGuard("c", time.Hour, usd(1_000_000), usd(50_000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+	// 1 WBTC (1e8 base units) at $60k → exceeds $50k single-tx → require approval
+	tx := &fakeTransfer{
+		amount: big.NewInt(100_000_000),
+		token:  tokenAddr,
+		status: TransferReady,
+	}
+	d, err := g.Check(tx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if d != DecisionRequireApproval {
+		t.Fatalf("expected require-approval, got %v", d)
+	}
+}
+
+func TestApprovalGuard_AlreadyAwaiting(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x4444")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "wbtc", Decimals: 8}}
+	prices := newFakePrices(map[string]float64{"wbtc": 60_000})
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("c", time.Hour, nil, usd(50_000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+	tx := &fakeTransfer{
+		amount: big.NewInt(100_000_000),
+		token:  tokenAddr,
+		status: TransferAwaitingApproval,
+	}
+	d, err := g.Check(tx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if d != DecisionAlreadyAwaiting {
+		t.Fatalf("expected already-awaiting, got %v", d)
+	}
+}
+
+func TestApprovalGuard_StalePriceBlocks(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x5555")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{}) // empty → all stale
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("c", time.Hour, usd(1000), usd(500), tokens, prices, rec, "", "")
+	var alerts int
+	g.larkAlerter = func(string) { alerts++ }
+	tx := &fakeTransfer{
+		amount: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+		token:  tokenAddr,
+		status: TransferReady,
+	}
+	d, err := g.Check(tx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if d != DecisionBlockWindow {
+		t.Fatalf("expected block-window when price is stale, got %v", d)
+	}
+	if alerts != 1 {
+		t.Fatalf("expected exactly one stale-price alert, got %d", alerts)
+	}
+	// Second call within 10-minute dedup window should NOT alert again.
+	_, _ = g.Check(tx)
+	if alerts != 1 {
+		t.Fatalf("expected alert dedup, got %d alerts", alerts)
+	}
+}
+
+func TestApprovalGuard_WindowAggregatesAcrossTokens(t *testing.T) {
+	wethAddr := common.HexToAddress("0x6661")
+	wbtcAddr := common.HexToAddress("0x6662")
+	tokens := []TokenMeta{
+		{Token: tokenKeyFor(wethAddr), CoinGeckoID: "weth", Decimals: 18},
+		{Token: tokenKeyFor(wbtcAddr), CoinGeckoID: "wbtc", Decimals: 8},
+	}
+	prices := newFakePrices(map[string]float64{"weth": 100, "wbtc": 60_000})
+	rec := newFakeRecorder(map[string]int64{})
+	// 5 WETH already signed = $500
+	rec.totals[tokenKeyFor(wethAddr)] = new(big.Int).Mul(big.NewInt(5), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+	// 0.01 WBTC already signed = $600
+	rec.totals[tokenKeyFor(wbtcAddr)] = big.NewInt(1_000_000)
+	// Window total = $1100. Limit $1500 → adding 5 WETH = $500 → projected $1600 → block.
+	g := NewApprovalGuard("c", time.Hour, usd(1500), usd(10_000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{
+		amount: new(big.Int).Mul(big.NewInt(5), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)),
+		token:  wethAddr,
+		status: TransferReady,
+	}
+	d, err := g.Check(tx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if d != DecisionBlockWindow {
+		t.Fatalf("expected block-window with cross-token aggregation, got %v", d)
+	}
+}
+
+func TestApprovalGuard_NilLimitsDisableThemIndividually(t *testing.T) {
+	tokenAddr := common.HexToAddress("0x7777")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	// Pre-load $1B worth of signed WETH; only single-tx limit set, so window must not block.
+	huge := new(big.Int).Mul(big.NewInt(1_000_000_000), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+	rec := newFakeRecorder(map[string]int64{})
+	rec.totals[tokenKeyFor(tokenAddr)] = huge
+	g := NewApprovalGuard("c", time.Hour, nil, usd(50_000_000_000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+	tx := &fakeTransfer{
+		amount: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+		token:  tokenAddr,
+		status: TransferReady,
+	}
+	d, _ := g.Check(tx)
+	if d != DecisionAllow {
+		t.Fatalf("expected allow, got %v", d)
+	}
+}
+
+func TestApprovalGuard_RequestAndApproveHappyPath(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xbbbb")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, nil, usd(50), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	// 1 WETH at $100 exceeds the $50 single-tx limit.
+	tx := &fakeTransfer{
+		amount:  new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+		status:  TransferReady,
+		cashier: common.HexToAddress("0xaaaa"),
+		token:   tokenAddr,
+		tidx:    7,
+	}
+	tx.SetID(common.HexToHash("0xdead"))
+
+	if err := g.RequestApproval(tx); err != nil {
+		t.Fatalf("RequestApproval: %v", err)
+	}
+	if rec.awaitingCalls != 1 {
+		t.Fatalf("expected 1 MarkTransferAwaitingApproval, got %d", rec.awaitingCalls)
+	}
+
+	g.mu.Lock()
+	pa, ok := g.pending["000000000000000000000000000000000000000000000000000000000000dead"]
+	if !ok {
+		t.Fatal("transfer not recorded in pending")
+	}
+	nonce := pa.nonce
+	g.mu.Unlock()
+
+	cb := util.LarkCallback{
+		OpenID:     "ou_admin",
+		TransferID: "0x000000000000000000000000000000000000000000000000000000000000dead",
+		Cashier:    "cashier1",
+		Nonce:      nonce,
+		Action:     "approve",
+	}
+	approved, err := g.Approve(cb)
+	if err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if !approved {
+		t.Fatal("expected approved=true")
+	}
+	if rec.approveCalls != 1 {
+		t.Fatalf("expected 1 ApproveTransferToReady, got %d", rec.approveCalls)
+	}
+}
+
+func TestApprovalGuard_RejectHappyPath(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xbbbc")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, nil, usd(50), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{
+		amount:  new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+		status:  TransferReady,
+		cashier: common.HexToAddress("0xaaaa"),
+		token:   tokenAddr,
+		tidx:    8,
+	}
+	tx.SetID(common.HexToHash("0x1234"))
+
+	if err := g.RequestApproval(tx); err != nil {
+		t.Fatalf("RequestApproval: %v", err)
+	}
+
+	g.mu.Lock()
+	pa, ok := g.pending["0000000000000000000000000000000000000000000000000000000000001234"]
+	if !ok {
+		t.Fatal("transfer not recorded in pending")
+	}
+	nonce := pa.nonce
+	g.mu.Unlock()
+
+	cb := util.LarkCallback{
+		OpenID:     "ou_admin",
+		TransferID: "0x0000000000000000000000000000000000000000000000000000000000001234",
+		Cashier:    "cashier1",
+		Nonce:      nonce,
+		Action:     "reject",
+	}
+	rejected, err := g.Reject(cb)
+	if err != nil {
+		t.Fatalf("Reject: %v", err)
+	}
+	if !rejected {
+		t.Fatal("expected rejected=true")
+	}
+	if rec.rejectCalls != 1 {
+		t.Fatalf("expected 1 RejectTransfer, got %d", rec.rejectCalls)
+	}
+	if rec.approveCalls != 0 {
+		t.Fatalf("expected 0 ApproveTransferToReady, got %d", rec.approveCalls)
+	}
+}
+
+func TestApprovalGuard_DecisionLocked_ApproveBlocksReject(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xbbbe")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, nil, usd(50), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{
+		amount:  new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+		status:  TransferReady,
+		cashier: common.HexToAddress("0xaaaa"),
+		token:   tokenAddr,
+		tidx:    9,
+	}
+	tx.SetID(common.HexToHash("0x5678"))
+
+	if err := g.RequestApproval(tx); err != nil {
+		t.Fatalf("RequestApproval: %v", err)
+	}
+
+	g.mu.Lock()
+	nonce := g.pending["0000000000000000000000000000000000000000000000000000000000005678"].nonce
+	g.mu.Unlock()
+
+	// Admin1 approves first.
+	cb1 := util.LarkCallback{
+		OpenID: "ou_admin1", TransferID: "0x0000000000000000000000000000000000000000000000000000000000005678",
+		Cashier: "cashier1", Nonce: nonce, Action: "approve",
+	}
+	if _, err := g.Approve(cb1); err != nil {
+		t.Fatalf("first Approve: %v", err)
+	}
+
+	// Admin2 tries to reject — must be blocked because decision is locked.
+	cb2 := util.LarkCallback{
+		OpenID: "ou_admin2", TransferID: "0x0000000000000000000000000000000000000000000000000000000000005678",
+		Cashier: "cashier1", Nonce: nonce, Action: "reject",
+	}
+	if _, err := g.Reject(cb2); err == nil {
+		t.Fatal("expected error when second admin tries to overwrite decision")
+	}
+
+	// Same admin1 also cannot approve again.
+	cb3 := util.LarkCallback{
+		OpenID: "ou_admin1", TransferID: "0x0000000000000000000000000000000000000000000000000000000000005678",
+		Cashier: "cashier1", Nonce: nonce, Action: "approve",
+	}
+	if _, err := g.Approve(cb3); err == nil {
+		t.Fatal("expected error when same admin tries to approve again")
+	}
+
+	if rec.approveCalls != 1 {
+		t.Fatalf("expected exactly 1 ApproveTransferToReady, got %d", rec.approveCalls)
+	}
+	if rec.rejectCalls != 0 {
+		t.Fatalf("expected 0 RejectTransfer, got %d", rec.rejectCalls)
+	}
+}
+
+func TestApprovalGuard_DecisionLocked_RejectBlocksApprove(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xbbbf")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, nil, usd(50), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{
+		amount:  new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+		status:  TransferReady,
+		cashier: common.HexToAddress("0xaaaa"),
+		token:   tokenAddr,
+		tidx:    10,
+	}
+	tx.SetID(common.HexToHash("0x9abc"))
+
+	if err := g.RequestApproval(tx); err != nil {
+		t.Fatalf("RequestApproval: %v", err)
+	}
+
+	g.mu.Lock()
+	nonce := g.pending["0000000000000000000000000000000000000000000000000000000000009abc"].nonce
+	g.mu.Unlock()
+
+	// Admin1 rejects first.
+	cb1 := util.LarkCallback{
+		OpenID: "ou_admin1", TransferID: "0x0000000000000000000000000000000000000000000000000000000000009abc",
+		Cashier: "cashier1", Nonce: nonce, Action: "reject",
+	}
+	if _, err := g.Reject(cb1); err != nil {
+		t.Fatalf("first Reject: %v", err)
+	}
+
+	// Admin2 tries to approve — must be blocked.
+	cb2 := util.LarkCallback{
+		OpenID: "ou_admin2", TransferID: "0x0000000000000000000000000000000000000000000000000000000000009abc",
+		Cashier: "cashier1", Nonce: nonce, Action: "approve",
+	}
+	if _, err := g.Approve(cb2); err == nil {
+		t.Fatal("expected error when second admin tries to overwrite reject decision")
+	}
+
+	if rec.rejectCalls != 1 {
+		t.Fatalf("expected exactly 1 RejectTransfer, got %d", rec.rejectCalls)
+	}
+	if rec.approveCalls != 0 {
+		t.Fatalf("expected 0 ApproveTransferToReady, got %d", rec.approveCalls)
+	}
+}
+
+func TestApprovalGuard_NonceReplay(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xeeee")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	g := NewApprovalGuard("c", time.Hour, nil, usd(50), tokens, prices, newFakeRecorder(map[string]int64{}), "", "")
+	if g.SeenNonce("abc") {
+		t.Fatal("first sighting reported as duplicate")
+	}
+	if !g.SeenNonce("abc") {
+		t.Fatal("second sighting not detected as duplicate")
+	}
+}
+
+func TestVerifyLarkCallbackSignature_RoundTrip(t *testing.T) {
+	secret := "topsecret"
+	ts := "1700000000"
+	nonce := "abc"
+	body := []byte(`{"event":"test"}`)
+	sig := computeLarkSig(secret, ts, nonce, body)
+	if !util.VerifyLarkCallbackSignature(secret, ts, nonce, body, sig) {
+		t.Fatal("matching sig did not verify")
+	}
+	if util.VerifyLarkCallbackSignature(secret, ts, nonce, body, "AAAA") {
+		t.Fatal("bogus sig verified")
+	}
+}
+
+func TestApprovalGuard_ConcurrentSafety(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xffff")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("c", time.Hour, usd(1_000_000), usd(1000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tx := &fakeTransfer{
+				amount: big.NewInt(50),
+				token:  tokenAddr,
+				status: TransferReady,
+			}
+			_, _ = g.Check(tx)
+			g.SeenNonce("nonce-shared")
+		}()
+	}
+	wg.Wait()
+}
+
+// --- ApprovalGuard error-path tests ----------------------------------------
+
+func TestApprovalGuard_UnknownTransfer(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xaaa1")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	g := NewApprovalGuard("c", time.Hour, nil, usd(50), tokens, newFakePrices(map[string]float64{"weth": 1}), newFakeRecorder(map[string]int64{}), "", "")
+	g.larkAlerter = func(string) {}
+
+	cb := util.LarkCallback{OpenID: "ou_x", TransferID: "0xdeadbeef", Cashier: "c", Nonce: "anynonce", Action: "approve"}
+	if _, err := g.Approve(cb); err == nil {
+		t.Fatal("expected error for unknown transfer")
+	}
+}
+
+func TestApprovalGuard_BadNonce(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xaaa2")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("c", time.Hour, nil, usd(50), tokens, newFakePrices(map[string]float64{"weth": 100}), rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{amount: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), token: tokenAddr, status: TransferReady}
+	tx.SetID(common.HexToHash("0xbad1"))
+	if err := g.RequestApproval(tx); err != nil {
+		t.Fatalf("RequestApproval: %v", err)
+	}
+
+	cb := util.LarkCallback{
+		OpenID: "ou_x", TransferID: "0x" + strings.Repeat("0", 63) + "1",
+		Cashier: "c", Nonce: "wrong-nonce", Action: "approve",
+	}
+	if _, err := g.Approve(cb); err == nil {
+		t.Fatal("expected nonce mismatch error")
+	}
+	if rec.approveCalls != 0 {
+		t.Fatal("DB must not be touched on nonce mismatch")
+	}
+}
+
+func TestApprovalGuard_RequestApproval_Idempotent(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xaaa3")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("c", time.Hour, nil, usd(50), tokens, newFakePrices(map[string]float64{"weth": 100}), rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{amount: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), token: tokenAddr, status: TransferReady}
+	tx.SetID(common.HexToHash("0xidmp"))
+	if err := g.RequestApproval(tx); err != nil {
+		t.Fatalf("first RequestApproval: %v", err)
+	}
+	if err := g.RequestApproval(tx); err != nil {
+		t.Fatalf("second RequestApproval: %v", err)
+	}
+	if rec.awaitingCalls != 1 {
+		t.Fatalf("expected exactly 1 DB call, got %d", rec.awaitingCalls)
+	}
+}
+
+// --- ApprovalServer routing tests -------------------------------------------
+
+// buildCallbackBody returns a minimal Lark card callback JSON for the given
+// transfer ID, cashier, nonce, and action.
+func buildCallbackBody(transferID, cashier, nonce, action string) []byte {
+	v := map[string]interface{}{
+		"transferID": transferID,
+		"cashier":    cashier,
+		"nonce":      nonce,
+		"action":     action,
+	}
+	body, _ := json.Marshal(map[string]interface{}{
+		"event": map[string]interface{}{
+			"operator": map[string]string{"open_id": "ou_any"},
+			"action":   map[string]interface{}{"value": v, "form_value": map[string]string{}},
+		},
+	})
+	return body
+}
+
+func setupServerWithPendingTransfer(t *testing.T, action string) (rec *fakeRecorder, w *httptest.ResponseRecorder) {
+	t.Helper()
+	tokenAddr := common.HexToAddress("0xbbba")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	rec = newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, nil, usd(50), tokens, newFakePrices(map[string]float64{"weth": 100}), rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	txHash := common.HexToHash("0xcafe")
+	tx := &fakeTransfer{
+		amount: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+		status: TransferReady, cashier: common.HexToAddress("0xaaaa"),
+		token: tokenAddr, tidx: 1,
+	}
+	tx.SetID(txHash)
+	if err := g.RequestApproval(tx); err != nil {
+		t.Fatalf("RequestApproval: %v", err)
+	}
+
+	pendingKey := hex.EncodeToString(txHash[:])
+	g.mu.Lock()
+	nonce := g.pending[pendingKey].nonce
+	g.mu.Unlock()
+
+	srv := NewApprovalServer("", "", map[string]*ApprovalGuard{"cashier1": g})
+	body := buildCallbackBody("0x"+pendingKey, "cashier1", nonce, action)
+	req := httptest.NewRequest(http.MethodPost, "/lark/callback", strings.NewReader(string(body)))
+	req.Header.Set("X-Lark-Request-Nonce", fmt.Sprintf("uniq-%s", action))
+	w = httptest.NewRecorder()
+	srv.handleCallback(w, req)
+	return rec, w
+}
+
+func TestApprovalServer_RouteApprove(t *testing.T) {
+	rec, w := setupServerWithPendingTransfer(t, "approve")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if rec.approveCalls != 1 {
+		t.Fatalf("expected 1 approve DB call, got %d", rec.approveCalls)
+	}
+	if rec.rejectCalls != 0 {
+		t.Fatalf("expected 0 reject DB calls, got %d", rec.rejectCalls)
+	}
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+	toast := resp["toast"].(map[string]interface{})
+	if toast["content"] != "transfer approved" {
+		t.Fatalf("unexpected toast: %v", toast["content"])
+	}
+}
+
+func TestApprovalServer_RouteReject(t *testing.T) {
+	rec, w := setupServerWithPendingTransfer(t, "reject")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if rec.rejectCalls != 1 {
+		t.Fatalf("expected 1 reject DB call, got %d", rec.rejectCalls)
+	}
+	if rec.approveCalls != 0 {
+		t.Fatalf("expected 0 approve DB calls, got %d", rec.approveCalls)
+	}
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+	toast := resp["toast"].(map[string]interface{})
+	if toast["content"] != "transfer rejected" {
+		t.Fatalf("unexpected toast: %v", toast["content"])
+	}
+}
+
+func TestApprovalServer_AlreadyDecided(t *testing.T) {
+	// First approve succeeds; second call (different Lark nonce) hits "already decided".
+	tokenAddr := common.HexToAddress("0xbbbd")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, nil, usd(50), tokens, newFakePrices(map[string]float64{"weth": 100}), rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{
+		amount: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+		status: TransferReady, cashier: common.HexToAddress("0xaaaa"),
+		token: tokenAddr, tidx: 2,
+	}
+	txHash2 := common.HexToHash("0xd00d")
+	tx.SetID(txHash2)
+	if err := g.RequestApproval(tx); err != nil {
+		t.Fatalf("RequestApproval: %v", err)
+	}
+	pendingKey2 := hex.EncodeToString(txHash2[:])
+	g.mu.Lock()
+	nonce := g.pending[pendingKey2].nonce
+	g.mu.Unlock()
+
+	srv := NewApprovalServer("", "", map[string]*ApprovalGuard{"cashier1": g})
+	body := buildCallbackBody("0x"+pendingKey2, "cashier1", nonce, "approve")
+
+	// First click — succeeds.
+	req1 := httptest.NewRequest(http.MethodPost, "/lark/callback", strings.NewReader(string(body)))
+	req1.Header.Set("X-Lark-Request-Nonce", "uniq-1")
+	srv.handleCallback(httptest.NewRecorder(), req1)
+
+	// Second click — different Lark nonce so SeenNonce passes, but guard blocks.
+	req2 := httptest.NewRequest(http.MethodPost, "/lark/callback", strings.NewReader(string(body)))
+	req2.Header.Set("X-Lark-Request-Nonce", "uniq-2")
+	w2 := httptest.NewRecorder()
+	srv.handleCallback(w2, req2)
+
+	var resp map[string]interface{}
+	json.NewDecoder(w2.Body).Decode(&resp)
+	toast := resp["toast"].(map[string]interface{})
+	if toast["type"] != "error" {
+		t.Fatalf("expected error toast for already-decided, got type=%v content=%v", toast["type"], toast["content"])
+	}
+	if rec.approveCalls != 1 {
+		t.Fatalf("DB must be called exactly once, got %d", rec.approveCalls)
+	}
+}
+
+// TestApprovalGuard_PostRestart_ApproveFallback covers the case where the
+// witness restarted after a transfer was flipped to `approval`: g.pending is
+// empty, but the DB row is still there and the admin clicks Approve. The
+// resolveTarget fallback uses cb.Token + cb.Tidx + g.cashierKey for the
+// UPDATE; DB atomicity (status='approval' filter) enforces one-shot.
+func TestApprovalGuard_PostRestart_ApproveFallback(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xc101")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, nil, usd(50), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	// Simulate restart: no pending entry, but a valid card payload arrives.
+	cb := util.LarkCallback{
+		OpenID:     "ou_admin",
+		TransferID: "0x00000000000000000000000000000000000000000000000000000000c0ffee01",
+		Cashier:    "cashier1",
+		Token:      util.ETHAddressToAddress(tokenAddr).String(),
+		Tidx:       42,
+		Nonce:      "stale-nonce-from-old-card",
+		Action:     "approve",
+	}
+
+	approved, err := g.Approve(cb)
+	if err != nil {
+		t.Fatalf("Approve fallback: %v", err)
+	}
+	if !approved {
+		t.Fatal("expected fallback approve to report ok=true (fake recorder returns true)")
+	}
+	if rec.approveCalls != 1 {
+		t.Fatalf("expected ApproveTransferToReady called once, got %d", rec.approveCalls)
+	}
+}
+
+// TestApprovalGuard_PostRestart_RejectFallback mirrors the Approve fallback
+// for the Reject path.
+func TestApprovalGuard_PostRestart_RejectFallback(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xc102")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, nil, usd(50), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	cb := util.LarkCallback{
+		OpenID:     "ou_admin",
+		TransferID: "0x00000000000000000000000000000000000000000000000000000000c0ffee02",
+		Cashier:    "cashier1",
+		Token:      util.ETHAddressToAddress(tokenAddr).String(),
+		Tidx:       43,
+		Action:     "reject",
+	}
+
+	rejected, err := g.Reject(cb)
+	if err != nil {
+		t.Fatalf("Reject fallback: %v", err)
+	}
+	if !rejected {
+		t.Fatal("expected fallback reject to report ok=true")
+	}
+	if rec.rejectCalls != 1 {
+		t.Fatalf("expected RejectTransfer called once, got %d", rec.rejectCalls)
+	}
+}
+
+// TestApprovalGuard_PostRestart_MissingPayloadRejects ensures the fallback
+// path errors out if the callback didn't carry token/tidx — otherwise an
+// attacker who guesses a transferID could trigger an UPDATE against
+// arbitrary cashier rows.
+func TestApprovalGuard_PostRestart_MissingPayloadRejects(t *testing.T) {
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("cashier1", time.Hour, nil, usd(50), nil, newFakePrices(map[string]float64{}), rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	cb := util.LarkCallback{
+		OpenID:     "ou_admin",
+		TransferID: "0x00000000000000000000000000000000000000000000000000000000c0ffee03",
+		Cashier:    "cashier1",
+		// Token + Tidx intentionally empty
+		Action: "approve",
+	}
+	if _, err := g.Approve(cb); err == nil {
+		t.Fatal("expected error when callback has no pending entry and no token/tidx")
+	}
+	if rec.approveCalls != 0 {
+		t.Fatalf("DB must not be called when fallback payload is incomplete, got %d", rec.approveCalls)
+	}
+}
+
+func TestAmountToUSD_Examples(t *testing.T) {
+	cases := []struct {
+		name     string
+		amount   *big.Int
+		decimals int
+		price    *big.Float
+		want     float64
+	}{
+		{"1 WETH @ $3000", new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), 18, big.NewFloat(3000), 3000},
+		{"0.5 WBTC @ $60000", big.NewInt(50_000_000), 8, big.NewFloat(60_000), 30_000},
+		{"100 USDC @ $1", big.NewInt(100_000_000), 6, big.NewFloat(1), 100},
+		{"zero decimals", big.NewInt(7), 0, big.NewFloat(2), 14},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := amountToUSD(tc.amount, tc.decimals, tc.price)
+			gotF, _ := got.Float64()
+			if gotF != tc.want {
+				t.Fatalf("got %v, want %v", gotF, tc.want)
+			}
+		})
+	}
+}

--- a/witness-service/witness/approval_test.go
+++ b/witness-service/witness/approval_test.go
@@ -90,7 +90,7 @@ func (f *fakeRecorder) MarkTransferAwaitingApproval(AbstractTransfer) error {
 	f.awaitingCalls++
 	return nil
 }
-func (f *fakeRecorder) ApproveTransferToReady(string, string, uint64) (bool, error) {
+func (f *fakeRecorder) ApproveTransfer(string, string, uint64) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.approveCalls++
@@ -400,7 +400,7 @@ func TestApprovalGuard_RequestAndApproveHappyPath(t *testing.T) {
 		t.Fatal("expected approved=true")
 	}
 	if rec.approveCalls != 1 {
-		t.Fatalf("expected 1 ApproveTransferToReady, got %d", rec.approveCalls)
+		t.Fatalf("expected 1 ApproveTransfer, got %d", rec.approveCalls)
 	}
 }
 
@@ -451,7 +451,7 @@ func TestApprovalGuard_RejectHappyPath(t *testing.T) {
 		t.Fatalf("expected 1 RejectTransfer, got %d", rec.rejectCalls)
 	}
 	if rec.approveCalls != 0 {
-		t.Fatalf("expected 0 ApproveTransferToReady, got %d", rec.approveCalls)
+		t.Fatalf("expected 0 ApproveTransfer, got %d", rec.approveCalls)
 	}
 }
 
@@ -508,7 +508,7 @@ func TestApprovalGuard_DecisionLocked_ApproveBlocksReject(t *testing.T) {
 	}
 
 	if rec.approveCalls != 1 {
-		t.Fatalf("expected exactly 1 ApproveTransferToReady, got %d", rec.approveCalls)
+		t.Fatalf("expected exactly 1 ApproveTransfer, got %d", rec.approveCalls)
 	}
 	if rec.rejectCalls != 0 {
 		t.Fatalf("expected 0 RejectTransfer, got %d", rec.rejectCalls)
@@ -562,7 +562,7 @@ func TestApprovalGuard_DecisionLocked_RejectBlocksApprove(t *testing.T) {
 		t.Fatalf("expected exactly 1 RejectTransfer, got %d", rec.rejectCalls)
 	}
 	if rec.approveCalls != 0 {
-		t.Fatalf("expected 0 ApproveTransferToReady, got %d", rec.approveCalls)
+		t.Fatalf("expected 0 ApproveTransfer, got %d", rec.approveCalls)
 	}
 }
 
@@ -847,7 +847,7 @@ func TestApprovalGuard_PostRestart_ApproveFallback(t *testing.T) {
 		t.Fatal("expected fallback approve to report ok=true (fake recorder returns true)")
 	}
 	if rec.approveCalls != 1 {
-		t.Fatalf("expected ApproveTransferToReady called once, got %d", rec.approveCalls)
+		t.Fatalf("expected ApproveTransfer called once, got %d", rec.approveCalls)
 	}
 }
 

--- a/witness-service/witness/approval_test.go
+++ b/witness-service/witness/approval_test.go
@@ -929,3 +929,61 @@ func TestAmountToUSD_Examples(t *testing.T) {
 		})
 	}
 }
+
+func TestApprovalGuard_MuteAndStaleWarning(t *testing.T) {
+	rec := newFakeRecorder(map[string]int64{})
+	g := NewApprovalGuard("c", time.Hour, nil, nil, nil, newFakePrices(nil), rec, "", "")
+	var amu sync.Mutex
+	var alerts int
+	g.larkAlerter = func(string) { amu.Lock(); alerts++; amu.Unlock() }
+	read := func() int { amu.Lock(); defer amu.Unlock(); return alerts }
+
+	if g.IsHeightMuted(5) {
+		t.Fatal("height 5 should not be muted initially")
+	}
+
+	// First warning for height 5: empty webhook makes the card send fail, so the
+	// guard falls back to one text alert.
+	g.NotifyStaleFetchFailure(5)
+	if got := read(); got != 1 {
+		t.Fatalf("after first notify: alerts=%d, want 1", got)
+	}
+	// Immediate repeat is deduped.
+	g.NotifyStaleFetchFailure(5)
+	if got := read(); got != 1 {
+		t.Fatalf("after duplicate notify: alerts=%d, want 1 (deduped)", got)
+	}
+
+	// Mute height 5.
+	ok, err := g.Mute(util.LarkCallback{Height: 5, OpenID: "ou_admin"})
+	if err != nil || !ok {
+		t.Fatalf("Mute: ok=%v err=%v, want true,nil", ok, err)
+	}
+	if !g.IsHeightMuted(5) {
+		t.Fatal("height 5 should be muted after Mute")
+	}
+	if got := read(); got != 2 {
+		t.Fatalf("mute should emit one confirmation alert: alerts=%d, want 2", got)
+	}
+
+	// Muting again is idempotent and silent.
+	ok, err = g.Mute(util.LarkCallback{Height: 5, OpenID: "ou_admin"})
+	if err != nil || ok {
+		t.Fatalf("second Mute: ok=%v err=%v, want false,nil", ok, err)
+	}
+	if got := read(); got != 2 {
+		t.Fatalf("duplicate mute must be silent: alerts=%d, want 2", got)
+	}
+
+	// A muted height never warns again.
+	g.NotifyStaleFetchFailure(5)
+	if got := read(); got != 2 {
+		t.Fatalf("muted height must not warn: alerts=%d, want 2", got)
+	}
+
+	// A different height still warns.
+	g.NotifyStaleFetchFailure(6)
+	if got := read(); got != 3 {
+		t.Fatalf("new height should warn: alerts=%d, want 3", got)
+	}
+}

--- a/witness-service/witness/approval_test.go
+++ b/witness-service/witness/approval_test.go
@@ -944,12 +944,12 @@ func TestApprovalGuard_MuteAndStaleWarning(t *testing.T) {
 
 	// First warning for height 5: empty webhook makes the card send fail, so the
 	// guard falls back to one text alert.
-	g.NotifyStaleFetchFailure(5)
+	g.NotifyStaleFetchFailure("c", 5)
 	if got := read(); got != 1 {
 		t.Fatalf("after first notify: alerts=%d, want 1", got)
 	}
 	// Immediate repeat is deduped.
-	g.NotifyStaleFetchFailure(5)
+	g.NotifyStaleFetchFailure("c", 5)
 	if got := read(); got != 1 {
 		t.Fatalf("after duplicate notify: alerts=%d, want 1 (deduped)", got)
 	}
@@ -976,13 +976,13 @@ func TestApprovalGuard_MuteAndStaleWarning(t *testing.T) {
 	}
 
 	// A muted height never warns again.
-	g.NotifyStaleFetchFailure(5)
+	g.NotifyStaleFetchFailure("c", 5)
 	if got := read(); got != 2 {
 		t.Fatalf("muted height must not warn: alerts=%d, want 2", got)
 	}
 
 	// A different height still warns.
-	g.NotifyStaleFetchFailure(6)
+	g.NotifyStaleFetchFailure("c", 6)
 	if got := read(); got != 3 {
 		t.Fatalf("new height should warn: alerts=%d, want 3", got)
 	}

--- a/witness-service/witness/recorder.go
+++ b/witness-service/witness/recorder.go
@@ -344,14 +344,14 @@ func (recorder *Recorder) MarkTransferAwaitingApproval(at AbstractTransfer) erro
 	return err
 }
 
-// ApproveTransferToReady transitions an approval-held row to ready so the next
-// SubmitTransfers tick will sign it. Returns an error if no row was updated
-// (i.e. nothing in approval state for the key — likely an idempotent duplicate
-// callback or a stale approval).
-func (recorder *Recorder) ApproveTransferToReady(cashier, token string, tidx uint64) (bool, error) {
+// ApproveTransfer transitions an approval-held row to `approved` so the next
+// SubmitTransfers tick will sign it without re-evaluating the single-tx limit.
+// Returns (false, nil) when no row was updated (idempotent duplicate callback
+// or stale approval).
+func (recorder *Recorder) ApproveTransfer(cashier, token string, tidx uint64) (bool, error) {
 	result, err := recorder.store.DB().Exec(
 		fmt.Sprintf("UPDATE %s SET `status`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
-		TransferReady,
+		TransferApproved,
 		cashier,
 		token,
 		tidx,
@@ -439,13 +439,14 @@ func (recorder *Recorder) ConfirmTransfer(at AbstractTransfer) error {
 	}
 	log.Printf("mark transfer %s as confirmed", tx.id.Hex())
 	result, err := recorder.store.DB().Exec(
-		fmt.Sprintf("UPDATE %s SET `status`=?, `id`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
+		fmt.Sprintf("UPDATE %s SET `status`=?, `id`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status` IN (?, ?)", recorder.transferTableName),
 		SubmissionConfirmed,
 		tx.id.Hex(),
 		tx.cashier.Hex(),
 		tx.token.Hex(),
 		tx.index,
 		TransferReady,
+		TransferApproved,
 	)
 	if err != nil {
 		return err
@@ -461,7 +462,7 @@ func (recorder *Recorder) TransfersToSettle(cashier string) ([]AbstractTransfer,
 
 // TransfersToSubmit returns the list of transfers to submit
 func (recorder *Recorder) TransfersToSubmit(cashier string) ([]AbstractTransfer, error) {
-	return recorder.transfers(cashier, TransferNew, TransferReady)
+	return recorder.transfers(cashier, TransferNew, TransferReady, TransferApproved)
 }
 
 func (recorder *Recorder) transfers(cashier string, status ...TransferStatus) ([]AbstractTransfer, error) {

--- a/witness-service/witness/recorder.go
+++ b/witness-service/witness/recorder.go
@@ -15,6 +15,7 @@ import (
 	"math"
 	"math/big"
 	"strings"
+	"time"
 
 	solcommon "github.com/blocto/solana-go-sdk/common"
 	"github.com/ethereum/go-ethereum/common"
@@ -314,8 +315,120 @@ func (recorder *Recorder) MarkTransferAsPending(at AbstractTransfer) error {
 		TransferNew,
 	)
 	if err != nil {
+		return err
 	}
 	return validateResult(result)
+}
+
+// MarkTransferAwaitingApproval flips a ready transfer that exceeded the
+// single-tx value limit to `approval`. Returns no error if the row is already
+// in `approval` (idempotent).
+func (recorder *Recorder) MarkTransferAwaitingApproval(at AbstractTransfer) error {
+	tx, ok := at.(*Transfer)
+	if !ok {
+		return errors.Errorf("invalid transfer type %T", at)
+	}
+	log.Printf("mark transfer %s as awaiting approval", tx.id.Hex())
+	result, err := recorder.store.DB().Exec(
+		fmt.Sprintf("UPDATE %s SET `status`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
+		TransferAwaitingApproval,
+		tx.cashier.Hex(),
+		tx.token.Hex(),
+		tx.index,
+		TransferReady,
+	)
+	if err != nil {
+		return err
+	}
+	_, err = result.RowsAffected()
+	return err
+}
+
+// ApproveTransferToReady transitions an approval-held row to ready so the next
+// SubmitTransfers tick will sign it. Returns an error if no row was updated
+// (i.e. nothing in approval state for the key — likely an idempotent duplicate
+// callback or a stale approval).
+func (recorder *Recorder) ApproveTransferToReady(cashier, token string, tidx uint64) (bool, error) {
+	result, err := recorder.store.DB().Exec(
+		fmt.Sprintf("UPDATE %s SET `status`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
+		TransferReady,
+		cashier,
+		token,
+		tidx,
+		TransferAwaitingApproval,
+	)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+// RejectTransfer transitions an approval-held EVM transfer to rejected so it
+// is never signed. Returns (false, nil) if the row was not in approval state
+// (idempotent — already handled by another code path).
+func (recorder *Recorder) RejectTransfer(cashier, token string, tidx uint64) (bool, error) {
+	result, err := recorder.store.DB().Exec(
+		fmt.Sprintf("UPDATE %s SET `status`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
+		TransferRejected,
+		cashier,
+		token,
+		tidx,
+		TransferAwaitingApproval,
+	)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+// SignedAmountSince returns the per-token sum of amounts on this cashier
+// whose status indicates they have already been signed (pending / confirmed /
+// settled) and whose `updateTime` is at or after `since`. Keys are the
+// lowercase hex of the token address bytes (no `0x` prefix). Used by
+// ApprovalGuard to enforce the rolling-window USD limit; survives witness
+// restarts because state is derived from the DB.
+func (recorder *Recorder) SignedAmountSince(cashier string, since time.Time) (map[string]*big.Int, error) {
+	rows, err := recorder.store.DB().Query(
+		fmt.Sprintf(
+			"SELECT token, amount FROM %s WHERE cashier=? AND status IN (?, ?, ?) AND updateTime >= ?",
+			recorder.transferTableName,
+		),
+		cashier,
+		TransferPending,
+		SubmissionConfirmed,
+		TransferSettled,
+		since.UTC(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	totals := make(map[string]*big.Int)
+	for rows.Next() {
+		var token, raw string
+		if err := rows.Scan(&token, &raw); err != nil {
+			return nil, err
+		}
+		amount, ok := new(big.Int).SetString(raw, 10)
+		if !ok {
+			return nil, errors.Errorf("invalid amount %s in transfer table", raw)
+		}
+		key := strings.ToLower(strings.TrimPrefix(token, "0x"))
+		if existing, ok := totals[key]; ok {
+			existing.Add(existing, amount)
+		} else {
+			totals[key] = amount
+		}
+	}
+	return totals, rows.Err()
 }
 
 // ConfirmTransfer marks a record as confirmed

--- a/witness-service/witness/solrecorder.go
+++ b/witness-service/witness/solrecorder.go
@@ -14,6 +14,8 @@ import (
 	"log"
 	"math"
 	"math/big"
+	"strings"
+	"time"
 
 	solcommon "github.com/blocto/solana-go-sdk/common"
 	"github.com/ethereum/go-ethereum/common"
@@ -235,6 +237,111 @@ func (recorder *SOLRecorder) SettleTransfer(at AbstractTransfer) error {
 // MarkTransferAsPending marks a record as pending
 func (recorder *SOLRecorder) MarkTransferAsPending(at AbstractTransfer) error {
 	return nil
+}
+
+// MarkTransferAwaitingApproval flips an over-limit SOL transfer to the
+// `approval` status until an admin approves via MFA.
+func (recorder *SOLRecorder) MarkTransferAwaitingApproval(at AbstractTransfer) error {
+	tx, ok := at.(*solTransfer)
+	if !ok {
+		return errors.Errorf("invalid transfer type %T", at)
+	}
+	log.Printf("mark sol transfer %s as awaiting approval", tx.id.Hex())
+	result, err := recorder.store.DB().Exec(
+		fmt.Sprintf("UPDATE %s SET `status`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
+		TransferAwaitingApproval,
+		hex.EncodeToString(tx.cashier.Bytes()),
+		hex.EncodeToString(tx.token.Bytes()),
+		tx.index,
+		TransferReady,
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := result.RowsAffected(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ApproveTransferToReady is the SOL counterpart that resumes signing for a
+// previously-held transfer.
+func (recorder *SOLRecorder) ApproveTransferToReady(cashier, token string, tidx uint64) (bool, error) {
+	result, err := recorder.store.DB().Exec(
+		fmt.Sprintf("UPDATE %s SET `status`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
+		TransferReady,
+		cashier,
+		token,
+		tidx,
+		TransferAwaitingApproval,
+	)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+// RejectTransfer transitions a SOL approval-held transfer to rejected.
+func (recorder *SOLRecorder) RejectTransfer(cashier, token string, tidx uint64) (bool, error) {
+	result, err := recorder.store.DB().Exec(
+		fmt.Sprintf("UPDATE %s SET `status`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
+		TransferRejected,
+		cashier,
+		token,
+		tidx,
+		TransferAwaitingApproval,
+	)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+// SignedAmountSince — see Recorder.SignedAmountSince. SOL transfers skip the
+// pending/empty-sig registration step, so "signed" means confirmed or settled.
+// Keys are the lowercase hex of the 32-byte token pubkey (no prefix) —
+// matching what the AddTransfer path stores.
+func (recorder *SOLRecorder) SignedAmountSince(cashier string, since time.Time) (map[string]*big.Int, error) {
+	rows, err := recorder.store.DB().Query(
+		fmt.Sprintf(
+			"SELECT token, amount FROM %s WHERE cashier=? AND status IN (?, ?) AND updateTime >= ?",
+			recorder.transferTableName,
+		),
+		cashier,
+		SubmissionConfirmed,
+		TransferSettled,
+		since.UTC(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	totals := make(map[string]*big.Int)
+	for rows.Next() {
+		var token, raw string
+		if err := rows.Scan(&token, &raw); err != nil {
+			return nil, err
+		}
+		amount, ok := new(big.Int).SetString(raw, 10)
+		if !ok {
+			return nil, errors.Errorf("invalid amount %s", raw)
+		}
+		key := strings.ToLower(strings.TrimPrefix(token, "0x"))
+		if existing, ok := totals[key]; ok {
+			existing.Add(existing, amount)
+		} else {
+			totals[key] = amount
+		}
+	}
+	return totals, rows.Err()
 }
 
 // ConfirmTransfer marks a record as confirmed

--- a/witness-service/witness/solrecorder.go
+++ b/witness-service/witness/solrecorder.go
@@ -240,7 +240,7 @@ func (recorder *SOLRecorder) MarkTransferAsPending(at AbstractTransfer) error {
 }
 
 // MarkTransferAwaitingApproval flips an over-limit SOL transfer to the
-// `approval` status until an admin approves via MFA.
+// `approval` status until an admin approves via the Lark approval card.
 func (recorder *SOLRecorder) MarkTransferAwaitingApproval(at AbstractTransfer) error {
 	tx, ok := at.(*solTransfer)
 	if !ok {
@@ -264,12 +264,13 @@ func (recorder *SOLRecorder) MarkTransferAwaitingApproval(at AbstractTransfer) e
 	return nil
 }
 
-// ApproveTransferToReady is the SOL counterpart that resumes signing for a
-// previously-held transfer.
-func (recorder *SOLRecorder) ApproveTransferToReady(cashier, token string, tidx uint64) (bool, error) {
+// ApproveTransfer is the SOL counterpart that flips an approval-held transfer
+// to `approved` so the next signing tick will sign it without re-evaluating
+// the single-tx limit.
+func (recorder *SOLRecorder) ApproveTransfer(cashier, token string, tidx uint64) (bool, error) {
 	result, err := recorder.store.DB().Exec(
 		fmt.Sprintf("UPDATE %s SET `status`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
-		TransferReady,
+		TransferApproved,
 		cashier,
 		token,
 		tidx,
@@ -352,13 +353,14 @@ func (recorder *SOLRecorder) ConfirmTransfer(at AbstractTransfer) error {
 	}
 	log.Printf("mark transfer %s as confirmed", tx.id.Hex())
 	result, err := recorder.store.DB().Exec(
-		fmt.Sprintf("UPDATE %s SET `status`=?, `id`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status`=?", recorder.transferTableName),
+		fmt.Sprintf("UPDATE %s SET `status`=?, `id`=? WHERE `cashier`=? AND `token`=? AND `tidx`=? AND `status` IN (?, ?)", recorder.transferTableName),
 		SubmissionConfirmed,
 		tx.id.Hex(),
 		hex.EncodeToString(tx.cashier.Bytes()),
 		hex.EncodeToString(tx.token.Bytes()),
 		tx.index,
 		TransferReady,
+		TransferApproved,
 	)
 	if err != nil {
 		return err
@@ -374,19 +376,29 @@ func (recorder *SOLRecorder) TransfersToSettle(string) ([]AbstractTransfer, erro
 
 // TransfersToSubmit returns the list of transfers to submit
 func (recorder *SOLRecorder) TransfersToSubmit(string) ([]AbstractTransfer, error) {
-	return recorder.transfers(TransferReady)
+	return recorder.transfers(TransferReady, TransferApproved)
 }
 
-func (recorder *SOLRecorder) transfers(status TransferStatus) ([]AbstractTransfer, error) {
+func (recorder *SOLRecorder) transfers(statuses ...TransferStatus) ([]AbstractTransfer, error) {
+	if len(statuses) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.Repeat("?,", len(statuses))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]interface{}, 0, len(statuses))
+	for _, s := range statuses {
+		args = append(args, s)
+	}
 	rows, err := recorder.store.DB().Query(
 		fmt.Sprintf(
 			"SELECT cashier, token, tidx, sender, recipient, amount, payload, fee, status, id, blockHeight, txSignature, txSender "+
 				"FROM %s "+
-				"WHERE status=? "+
+				"WHERE status IN (%s) "+
 				"ORDER BY creationTime",
 			recorder.transferTableName,
+			placeholders,
 		),
-		status,
+		args...,
 	)
 	if err != nil {
 		return nil, err

--- a/witness-service/witness/tokencashierbase.go
+++ b/witness-service/witness/tokencashierbase.go
@@ -9,6 +9,7 @@ package witness
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"log"
 	"math/big"
 	"strings"
@@ -67,6 +68,9 @@ type (
 		start                  startStopFunc
 		stop                   startStopFunc
 		disablePull            bool
+		// guard enforces window + single-tx value limits before signing.
+		// nil ⇒ disabled (original behavior).
+		guard *ApprovalGuard
 	}
 	calcConfirmHeightFunc func(startHeight uint64, count uint16) (uint64, uint64, error)
 	pullTransfersFunc     func(startHeight uint64, endHeight uint64) ([]AbstractTransfer, error)
@@ -89,6 +93,7 @@ func newTokenCashierBase(
 	start startStopFunc,
 	stop startStopFunc,
 	disablePull bool,
+	guard *ApprovalGuard,
 ) TokenCashier {
 	return &tokenCashierBase{
 		id:                     id,
@@ -107,6 +112,7 @@ func newTokenCashierBase(
 		start:                  start,
 		stop:                   stop,
 		disablePull:            disablePull,
+		guard:                  guard,
 	}
 }
 
@@ -256,6 +262,43 @@ func (tc *tokenCashierBase) SubmitTransfers() error {
 	for _, transfer := range transfersToSubmit {
 		if !tc.hasEnoughBalance(transfer.Token(), transfer.Amount()) {
 			return errors.Errorf("not enough balance for token %s", transfer.Token())
+		}
+		// Security guard: enforce per-cashier window and single-tx value caps
+		// before producing a real signature.
+		if tc.guard != nil {
+			if transfer.Status() == TransferAwaitingApproval {
+				// Admin decision is still pending — never sign.
+				continue
+			}
+			if transfer.Status() == TransferReady {
+				decision, err := tc.guard.Check(transfer)
+				if err != nil {
+					// Fail closed: a security guard that can't evaluate its
+					// inputs must not authorize a signature. Skip this transfer
+					// and surface the failure; the next tick will retry once
+					// the underlying issue clears.
+					log.Printf("approval guard check error for transfer %x: %+v\n", transfer.ID(), err)
+					util.Alert(fmt.Sprintf(
+						"[witness:%s] approval guard error; pausing this transfer: %v",
+						tc.cashierContractAddr.String(), err,
+					))
+					continue
+				}
+				switch decision {
+				case DecisionBlockWindow:
+					tc.guard.NotifyWindowBlocked(transfer)
+					continue
+				case DecisionRequireApproval:
+					if err := tc.guard.RequestApproval(transfer); err != nil {
+						log.Printf("failed to request approval for transfer %x: %+v\n", transfer.ID(), err)
+					}
+					continue
+				case DecisionAlreadyAwaiting:
+					continue
+				case DecisionAllow:
+					// fall through to signing
+				}
+			}
 		}
 		id, pubkey, signature, err := tc.signHandler(transfer, tc.validatorContractAddr)
 		if err != nil {

--- a/witness-service/witness/tokencashierbase.go
+++ b/witness-service/witness/tokencashierbase.go
@@ -264,7 +264,10 @@ func (tc *tokenCashierBase) SubmitTransfers() error {
 			return errors.Errorf("not enough balance for token %s", transfer.Token())
 		}
 		// Security guard: enforce per-cashier window and single-tx value caps
-		// before producing a real signature.
+		// before producing a real signature. TransferApproved bypasses the
+		// guard — an admin has already authorized the single-tx amount; if we
+		// re-checked it here the same single-tx-limit rule would push it back
+		// into `approval` on the next tick.
 		if tc.guard != nil {
 			if transfer.Status() == TransferAwaitingApproval {
 				// Admin decision is still pending — never sign.
@@ -309,7 +312,8 @@ func (tc *tokenCashierBase) SubmitTransfers() error {
 			continue
 		}
 		var witness *types.Witness
-		if transfer.Status() == TransferReady {
+		signed := transfer.Status() == TransferReady || transfer.Status() == TransferApproved
+		if signed {
 			witness = &types.Witness{
 				Transfer:  transfer.ToTypesTransfer(),
 				Address:   pubkey,
@@ -330,7 +334,7 @@ func (tc *tokenCashierBase) SubmitTransfers() error {
 			log.Printf("something went wrong when submitting transfer (%s, %s, %s) for %s\n", transfer.Cashier(), transfer.Token(), transfer.Index().String(), id)
 			continue
 		}
-		if transfer.Status() == TransferReady {
+		if signed {
 			if err := tc.recorder.ConfirmTransfer(transfer); err != nil {
 				return err
 			}

--- a/witness-service/witness/tokencashierbase.go
+++ b/witness-service/witness/tokencashierbase.go
@@ -354,12 +354,65 @@ func (tc *tokenCashierBase) ProcessStales() error {
 	}
 	defer conn.Close()
 	relayer := services.NewRelayServiceClient(conn)
+
+	// Read the witness tip once for this tick. A stale height above the tip is
+	// not missing data — the witness simply has not caught up yet (e.g. after a
+	// restart) and will pull it on a later tick — so it must not raise a
+	// "source data deleted" alert.
+	tip, tipErr := tc.recorder.TipHeight(tc.id)
+
+	processStaleHeights := func(owner string, heights []uint64) {
+		for _, height := range heights {
+			if tc.guard != nil && tc.guard.IsHeightMuted(height) {
+				// Admin has muted this height (the source data is gone); skip it
+				// so it neither blocks the rest of the list nor re-alerts.
+				continue
+			}
+			if err := tc.PullTransfersByHeight(height); err != nil {
+				// Do not abort the whole list on one un-fetchable height — that
+				// would block every later stale height behind it forever.
+				if tipErr == nil && height > tip {
+					// Witness is behind, not missing data. Skip quietly; a later
+					// tick will pull it once the tip advances. (tip is stable
+					// within a tick: PullTransfersByHeight never advances the sync
+					// height — only PullTransfers does — and process() runs on a
+					// single goroutine, so reading it once here is safe.)
+					//
+					// Edge: if the tip is itself stuck below a pruned block (the
+					// witness can't advance past missing mid-range data), that
+					// height stays above tip and is never alerted here — but the
+					// stuck tip surfaces separately as a recurring PullTransfers
+					// failure. The common "old historical data deleted" case is
+					// always at/below tip and does alert below.
+					log.Printf("skipping stale height %d for %s: above current tip %d (catching up)\n", height, tc.id, tip)
+					continue
+				}
+				// The data should be available at or below the tip but isn't
+				// (pruned/deleted on the source API). Warn the admin
+				// (deduplicated) and continue; they resolve it manually
+				// (sign-witness/submit-witness) and/or mute it.
+				log.Printf("failed to pull stale transfers for %s (cashier %s) at height %d: %+v\n", tc.id, owner, height, err)
+				if tc.guard != nil {
+					tc.guard.NotifyStaleFetchFailure(owner, height)
+				} else {
+					util.Alert(fmt.Sprintf(
+						"[witness:%s] cannot fetch stale block %d for cashier %s (source data deleted); sign+submit manually (muting needs the approval card)",
+						tc.id, height, owner,
+					))
+				}
+				continue
+			}
+		}
+	}
+
 	response, err := relayer.StaleHeights(context.Background(), &services.StaleHeightsRequest{
 		Cashier: tc.cashierContractAddr.Bytes(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch stale heights")
 	}
+	processStaleHeights(tc.cashierContractAddr.String(), response.Heights)
+
 	if tc.previousCashierAddr != nil {
 		previousResponse, err := relayer.StaleHeights(context.Background(), &services.StaleHeightsRequest{
 			Cashier: tc.previousCashierAddr.Bytes(),
@@ -367,30 +420,7 @@ func (tc *tokenCashierBase) ProcessStales() error {
 		if err != nil {
 			return errors.Wrap(err, "failed to fetch stale heights from previous cashier")
 		}
-		response.Heights = append(response.Heights, previousResponse.Heights...)
-	}
-	for _, height := range response.Heights {
-		if tc.guard != nil && tc.guard.IsHeightMuted(height) {
-			// Admin has muted this height (the source data is gone); skip it so
-			// it neither blocks the rest of the list nor re-alerts.
-			continue
-		}
-		if err := tc.PullTransfersByHeight(height); err != nil {
-			// Do not abort the whole list on one un-fetchable height — that
-			// would block every later stale height behind it forever. Log,
-			// warn the admin (deduplicated), and continue. The admin resolves
-			// it manually (sign-witness/submit-witness) and/or mutes it.
-			log.Printf("failed to pull stale transfers for %s at height %d: %+v\n", tc.id, height, err)
-			if tc.guard != nil {
-				tc.guard.NotifyStaleFetchFailure(height)
-			} else {
-				util.Alert(fmt.Sprintf(
-					"[witness:%s] cannot fetch stale block %d (source data deleted); sign+submit manually",
-					tc.cashierContractAddr.String(), height,
-				))
-			}
-			continue
-		}
+		processStaleHeights(tc.previousCashierAddr.String(), previousResponse.Heights)
 	}
 	return nil
 }

--- a/witness-service/witness/tokencashierbase.go
+++ b/witness-service/witness/tokencashierbase.go
@@ -370,8 +370,26 @@ func (tc *tokenCashierBase) ProcessStales() error {
 		response.Heights = append(response.Heights, previousResponse.Heights...)
 	}
 	for _, height := range response.Heights {
+		if tc.guard != nil && tc.guard.IsHeightMuted(height) {
+			// Admin has muted this height (the source data is gone); skip it so
+			// it neither blocks the rest of the list nor re-alerts.
+			continue
+		}
 		if err := tc.PullTransfersByHeight(height); err != nil {
-			return errors.Wrap(err, "failed to pull transfers by height")
+			// Do not abort the whole list on one un-fetchable height — that
+			// would block every later stale height behind it forever. Log,
+			// warn the admin (deduplicated), and continue. The admin resolves
+			// it manually (sign-witness/submit-witness) and/or mutes it.
+			log.Printf("failed to pull stale transfers for %s at height %d: %+v\n", tc.id, height, err)
+			if tc.guard != nil {
+				tc.guard.NotifyStaleFetchFailure(height)
+			} else {
+				util.Alert(fmt.Sprintf(
+					"[witness:%s] cannot fetch stale block %d (source data deleted); sign+submit manually",
+					tc.cashierContractAddr.String(), height,
+				))
+			}
+			continue
 		}
 	}
 	return nil

--- a/witness-service/witness/tokencashierbase_test.go
+++ b/witness-service/witness/tokencashierbase_test.go
@@ -150,6 +150,58 @@ func TestSubmitTransfers_GuardAlreadyAwaiting(t *testing.T) {
 	}
 }
 
+func TestSubmitTransfers_ApprovedBypassesGuardCheck(t *testing.T) {
+	// Regression: an admin-approved transfer must not be re-evaluated by the
+	// guard, otherwise the single-tx-limit rule would push it back into
+	// `approval` on the next tick and the admin decision would be lost.
+	tokenAddr := common.HexToAddress("0xc005")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "wbtc", Decimals: 8}}
+	prices := newFakePrices(map[string]float64{"wbtc": 60_000})
+	rec := newFakeRecorder(map[string]int64{})
+
+	// 1 WBTC at $60k still exceeds the $50k single-tx limit. If Check were
+	// invoked it would return DecisionRequireApproval again.
+	g := NewApprovalGuard("0x0000000000000000000000000000000000000000000000000000000000636173",
+		time.Hour, nil, usd(50_000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{
+		cashier: common.HexToAddress("0xcash"),
+		token:   tokenAddr,
+		amount:  big.NewInt(100_000_000), // 1 WBTC
+		status:  TransferApproved,
+		tidx:    5,
+	}
+	tx.SetID(common.HexToHash("0x5555"))
+	rec.submittable = []AbstractTransfer{tx}
+
+	var signed int
+	signHandler := SignHandler(func(AbstractTransfer, []byte) (common.Hash, []byte, []byte, error) {
+		signed++
+		// nil signature short-circuits the relayer.Submit call.
+		return common.Hash{}, []byte("pubkey"), nil, nil
+	})
+
+	cashierAddr := util.ETHAddressToAddress(common.HexToAddress("0xcash"))
+	tc := newTokenCashierBase(
+		"test", cashierAddr, nil, rec, "localhost:0", []byte{}, 0,
+		nil, nil, signHandler,
+		func(util.Address, *big.Int) bool { return true },
+		nil, nil, false,
+		g,
+	).(*tokenCashierBase)
+
+	if err := tc.SubmitTransfers(); err != nil {
+		t.Fatalf("SubmitTransfers: %v", err)
+	}
+	if signed != 1 {
+		t.Fatalf("expected approved transfer to reach signHandler, got %d", signed)
+	}
+	if rec.awaitingCalls != 0 {
+		t.Fatalf("approved transfer must not be re-held; awaitingCalls=%d", rec.awaitingCalls)
+	}
+}
+
 func TestSubmitTransfers_NoGuard_SignsDirectly(t *testing.T) {
 	tokenAddr := common.HexToAddress("0xc004")
 	rec := newFakeRecorder(map[string]int64{})

--- a/witness-service/witness/tokencashierbase_test.go
+++ b/witness-service/witness/tokencashierbase_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package witness
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/iotexproject/ioTube/witness-service/util"
+)
+
+// panicSignHandler is a SignHandler that fails the test if called — guard-blocked
+// transfers must never reach signing.
+var panicSignHandler = SignHandler(func(AbstractTransfer, []byte) (common.Hash, []byte, []byte, error) {
+	panic("signHandler must not be called for guard-blocked transfers")
+})
+
+// newTestCashierBase builds a minimal tokenCashierBase for unit tests.
+// relayerURL is intentionally invalid — tests that exercise guard-blocked paths
+// never reach the gRPC submit call so no real server is needed.
+func newTestCashierBase(rec *fakeRecorder, guard *ApprovalGuard) *tokenCashierBase {
+	cashierAddr := util.ETHAddressToAddress(common.HexToAddress("0xcash"))
+	tc := newTokenCashierBase(
+		"test",
+		cashierAddr,
+		nil,
+		rec,
+		"localhost:0", // never dialed for blocked transfers
+		[]byte{},
+		0,
+		nil, // calcConfirmHeight — not used in SubmitTransfers
+		nil, // pullTransfers — not used in SubmitTransfers
+		panicSignHandler,
+		func(util.Address, *big.Int) bool { return true },
+		nil, nil,
+		false,
+		guard,
+	)
+	return tc.(*tokenCashierBase)
+}
+
+func TestSubmitTransfers_GuardRequireApproval(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xc001")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "wbtc", Decimals: 8}}
+	prices := newFakePrices(map[string]float64{"wbtc": 60_000})
+	rec := newFakeRecorder(map[string]int64{})
+
+	// 1 WBTC at $60k exceeds the $50k single-tx limit → RequireApproval
+	g := NewApprovalGuard("0x0000000000000000000000000000000000000000000000000000000000636173",
+		time.Hour, nil, usd(50_000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{
+		cashier: common.HexToAddress("0xcash"),
+		token:   tokenAddr,
+		amount:  big.NewInt(100_000_000), // 1 WBTC in base units
+		status:  TransferReady,
+		tidx:    1,
+	}
+	tx.SetID(common.HexToHash("0x1111"))
+	rec.submittable = []AbstractTransfer{tx}
+
+	tc := newTestCashierBase(rec, g)
+	if err := tc.SubmitTransfers(); err != nil {
+		t.Fatalf("SubmitTransfers: %v", err)
+	}
+
+	if rec.awaitingCalls != 1 {
+		t.Fatalf("expected transfer to be held for approval, awaitingCalls=%d", rec.awaitingCalls)
+	}
+	if rec.approveCalls != 0 {
+		t.Fatalf("transfer must not be signed, approveCalls=%d", rec.approveCalls)
+	}
+}
+
+func TestSubmitTransfers_GuardBlockWindow(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xc002")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "weth", Decimals: 18}}
+	prices := newFakePrices(map[string]float64{"weth": 100})
+	rec := newFakeRecorder(map[string]int64{})
+
+	// Pre-fill window with $950 already signed; 1 WETH = $100 → projected $1050 > $1000
+	rec.totals[tokenKeyFor(tokenAddr)] = new(big.Int).Mul(
+		big.NewInt(95), new(big.Int).Exp(big.NewInt(10), big.NewInt(17), nil),
+	)
+
+	g := NewApprovalGuard("0x0000000000000000000000000000000000000000000000000000000000636173",
+		time.Hour, usd(1000), usd(5000), tokens, prices, rec, "", "")
+	var alerts int
+	g.larkAlerter = func(string) { alerts++ }
+
+	tx := &fakeTransfer{
+		cashier: common.HexToAddress("0xcash"),
+		token:   tokenAddr,
+		amount:  new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), // 1 WETH
+		status:  TransferReady,
+		tidx:    2,
+	}
+	tx.SetID(common.HexToHash("0x2222"))
+	rec.submittable = []AbstractTransfer{tx}
+
+	tc := newTestCashierBase(rec, g)
+	if err := tc.SubmitTransfers(); err != nil {
+		t.Fatalf("SubmitTransfers: %v", err)
+	}
+
+	if rec.awaitingCalls != 0 {
+		t.Fatalf("window-blocked transfer must not enter approval, awaitingCalls=%d", rec.awaitingCalls)
+	}
+	if alerts != 1 {
+		t.Fatalf("expected 1 window-blocked alert, got %d", alerts)
+	}
+}
+
+func TestSubmitTransfers_GuardAlreadyAwaiting(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xc003")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "wbtc", Decimals: 8}}
+	prices := newFakePrices(map[string]float64{"wbtc": 60_000})
+	rec := newFakeRecorder(map[string]int64{})
+
+	g := NewApprovalGuard("0x0000000000000000000000000000000000000000000000000000000000636173",
+		time.Hour, nil, usd(50_000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	// Transfer already in the approval state — guard returns DecisionAlreadyAwaiting.
+	tx := &fakeTransfer{
+		cashier: common.HexToAddress("0xcash"),
+		token:   tokenAddr,
+		amount:  big.NewInt(100_000_000),
+		status:  TransferAwaitingApproval, // already held
+		tidx:    3,
+	}
+	tx.SetID(common.HexToHash("0x3333"))
+	rec.submittable = []AbstractTransfer{tx}
+
+	tc := newTestCashierBase(rec, g)
+	if err := tc.SubmitTransfers(); err != nil {
+		t.Fatalf("SubmitTransfers: %v", err)
+	}
+
+	// Nothing should have changed — no approve, no re-hold.
+	if rec.awaitingCalls != 0 {
+		t.Fatalf("already-awaiting must not trigger another hold, awaitingCalls=%d", rec.awaitingCalls)
+	}
+}
+
+func TestSubmitTransfers_NoGuard_SignsDirectly(t *testing.T) {
+	tokenAddr := common.HexToAddress("0xc004")
+	rec := newFakeRecorder(map[string]int64{})
+
+	var signed int
+	signHandler := SignHandler(func(AbstractTransfer, []byte) (common.Hash, []byte, []byte, error) {
+		signed++
+		// Return a nil signature so SubmitTransfers skips the relayer.Submit call
+		// (the `if signature == nil { continue }` guard in the code).
+		return common.Hash{}, []byte("pubkey"), nil, nil
+	})
+
+	tx := &fakeTransfer{
+		cashier: common.HexToAddress("0xcash"),
+		token:   tokenAddr,
+		amount:  big.NewInt(100_000_000),
+		status:  TransferReady,
+		tidx:    4,
+	}
+	tx.SetID(common.HexToHash("0x4444"))
+	rec.submittable = []AbstractTransfer{tx}
+
+	cashierAddr := util.ETHAddressToAddress(common.HexToAddress("0xcash"))
+	tc := newTokenCashierBase(
+		"test", cashierAddr, nil, rec, "localhost:0", []byte{}, 0,
+		nil, nil, signHandler,
+		func(util.Address, *big.Int) bool { return true },
+		nil, nil, false,
+		nil, // no guard
+	).(*tokenCashierBase)
+
+	if err := tc.SubmitTransfers(); err != nil {
+		t.Fatalf("SubmitTransfers: %v", err)
+	}
+	if signed != 1 {
+		t.Fatalf("expected signHandler called once, got %d", signed)
+	}
+}

--- a/witness-service/witness/tokencashierbase_test.go
+++ b/witness-service/witness/tokencashierbase_test.go
@@ -202,6 +202,75 @@ func TestSubmitTransfers_ApprovedBypassesGuardCheck(t *testing.T) {
 	}
 }
 
+func TestSubmitTransfers_AdminApprovedRoundTrip(t *testing.T) {
+	// End-to-end: a transfer that exceeds the single-tx limit is held on tick
+	// 1, then signed on tick 2 after an admin flips it from `approval` to
+	// `approved`. Validates that the approved bypass survives across ticks
+	// and that the row is not re-held.
+	tokenAddr := common.HexToAddress("0xc006")
+	tokens := []TokenMeta{{Token: tokenKeyFor(tokenAddr), CoinGeckoID: "wbtc", Decimals: 8}}
+	prices := newFakePrices(map[string]float64{"wbtc": 60_000})
+	rec := newFakeRecorder(map[string]int64{})
+
+	g := NewApprovalGuard("0x0000000000000000000000000000000000000000000000000000000000636173",
+		time.Hour, nil, usd(50_000), tokens, prices, rec, "", "")
+	g.larkAlerter = func(string) {}
+
+	tx := &fakeTransfer{
+		cashier: common.HexToAddress("0xcash"),
+		token:   tokenAddr,
+		amount:  big.NewInt(100_000_000), // 1 WBTC = $60k > $50k limit
+		status:  TransferReady,
+		tidx:    6,
+	}
+	tx.SetID(common.HexToHash("0x6666"))
+	rec.submittable = []AbstractTransfer{tx}
+
+	var signed int
+	signHandler := SignHandler(func(AbstractTransfer, []byte) (common.Hash, []byte, []byte, error) {
+		signed++
+		// nil signature short-circuits the relayer.Submit call.
+		return common.Hash{}, []byte("pubkey"), nil, nil
+	})
+
+	cashierAddr := util.ETHAddressToAddress(common.HexToAddress("0xcash"))
+	tc := newTokenCashierBase(
+		"test", cashierAddr, nil, rec, "localhost:0", []byte{}, 0,
+		nil, nil, signHandler,
+		func(util.Address, *big.Int) bool { return true },
+		nil, nil, false,
+		g,
+	).(*tokenCashierBase)
+
+	// Tick 1: over-limit ready row → held for approval.
+	if err := tc.SubmitTransfers(); err != nil {
+		t.Fatalf("tick 1: %v", err)
+	}
+	if rec.awaitingCalls != 1 {
+		t.Fatalf("tick 1: expected awaitingCalls=1, got %d", rec.awaitingCalls)
+	}
+	if signed != 0 {
+		t.Fatalf("tick 1: must not sign, signed=%d", signed)
+	}
+
+	// Admin approves. The real Recorder.ApproveTransfer flips the row from
+	// `approval` to `approved`; we mirror that effect on the in-memory fake
+	// so the next tick observes the new status.
+	tx.status = TransferApproved
+
+	// Tick 2: approved row bypasses guard.Check, reaches signHandler, is not
+	// re-held.
+	if err := tc.SubmitTransfers(); err != nil {
+		t.Fatalf("tick 2: %v", err)
+	}
+	if signed != 1 {
+		t.Fatalf("tick 2: expected signHandler called once, got %d", signed)
+	}
+	if rec.awaitingCalls != 1 {
+		t.Fatalf("tick 2: approved must not re-trigger hold, awaitingCalls=%d", rec.awaitingCalls)
+	}
+}
+
 func TestSubmitTransfers_NoGuard_SignsDirectly(t *testing.T) {
 	tokenAddr := common.HexToAddress("0xc004")
 	rec := newFakeRecorder(map[string]int64{})

--- a/witness-service/witness/tokencashieronethereum.go
+++ b/witness-service/witness/tokencashieronethereum.go
@@ -242,6 +242,7 @@ func NewTokenCashierOnEthereum(
 	signHandler SignHandler,
 	reverseRecorder *Recorder,
 	reverseCashierContractAddr common.Address,
+	guard *ApprovalGuard,
 ) (TokenCashier, error) {
 	iter, err := newIterator(version, cashierContractAddr, tokenSafeContractAddr, ethereumClient, nil)
 	if err != nil {
@@ -321,5 +322,6 @@ func NewTokenCashierOnEthereum(
 			return nil
 		},
 		false,
+		guard,
 	), nil
 }

--- a/witness-service/witness/tokencashieronsolana.go
+++ b/witness-service/witness/tokencashieronsolana.go
@@ -157,6 +157,7 @@ func NewTokenCashierOnSolana(
 			return nil
 		},
 		disablePull,
+		nil, // no approval guard for Solana cashiers
 	), nil
 }
 

--- a/witness-service/witness/types.go
+++ b/witness-service/witness/types.go
@@ -9,6 +9,7 @@ package witness
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -57,6 +58,15 @@ type (
 		SettleTransfer(tx AbstractTransfer) error
 		ConfirmTransfer(tx AbstractTransfer) error
 		MarkTransferAsPending(tx AbstractTransfer) error
+		MarkTransferAwaitingApproval(tx AbstractTransfer) error
+		ApproveTransferToReady(cashier, token string, tidx uint64) (bool, error)
+		RejectTransfer(cashier, token string, tidx uint64) (bool, error)
+		// SignedAmountSince returns, for transfers on `cashier` whose status
+		// indicates they have already been signed and whose updateTime is at
+		// or after `since`, the sum of token amounts grouped by token. The
+		// returned keys are the lowercase hex of the token's raw bytes — no
+		// `0x` prefix — so callers must normalize on the same shape.
+		SignedAmountSince(cashier string, since time.Time) (map[string]*big.Int, error)
 	}
 
 	AbstractTransfer interface {
@@ -91,6 +101,13 @@ const (
 	TransferSettled = "settled"
 	// TransferInvalid stands for an invalid transfer
 	TransferInvalid = "invalid"
+	// TransferAwaitingApproval marks a transfer that exceeded the per-tx value
+	// limit and needs manual MFA approval before it can be signed. Kept to 8
+	// chars to fit the existing `status` varchar(10) column.
+	TransferAwaitingApproval = "approval"
+	// TransferRejected marks a transfer that an admin explicitly rejected via
+	// the Lark approval card. Rejected transfers are never signed.
+	TransferRejected = "rejected"
 
 	// NoPayload is version without payload
 	NoPayload Version = "no-payload"

--- a/witness-service/witness/types.go
+++ b/witness-service/witness/types.go
@@ -59,7 +59,7 @@ type (
 		ConfirmTransfer(tx AbstractTransfer) error
 		MarkTransferAsPending(tx AbstractTransfer) error
 		MarkTransferAwaitingApproval(tx AbstractTransfer) error
-		ApproveTransferToReady(cashier, token string, tidx uint64) (bool, error)
+		ApproveTransfer(cashier, token string, tidx uint64) (bool, error)
 		RejectTransfer(cashier, token string, tidx uint64) (bool, error)
 		// SignedAmountSince returns, for transfers on `cashier` whose status
 		// indicates they have already been signed and whose updateTime is at
@@ -102,9 +102,14 @@ const (
 	// TransferInvalid stands for an invalid transfer
 	TransferInvalid = "invalid"
 	// TransferAwaitingApproval marks a transfer that exceeded the per-tx value
-	// limit and needs manual MFA approval before it can be signed. Kept to 8
+	// limit and needs manual admin approval before it can be signed. Kept to 8
 	// chars to fit the existing `status` varchar(10) column.
 	TransferAwaitingApproval = "approval"
+	// TransferApproved marks a transfer that an admin explicitly approved via
+	// the Lark approval card. The signing loop treats it like TransferReady but
+	// skips the guard's single-tx limit check so the admin decision is not
+	// undone on the next tick.
+	TransferApproved = "approved"
 	// TransferRejected marks a transfer that an admin explicitly rejected via
 	// the Lark approval card. Rejected transfers are never signed.
 	TransferRejected = "rejected"


### PR DESCRIPTION
## Summary
This branch adds two related witness-side safety features that share the same Lark-card / approval-server infrastructure:

### 1. Pre-sign approval guard (USD-based caps)
- Adds an `ApprovalGuard` that gates witness signing on a per-cashier rolling-window USD cap and a per-transfer USD cap, with Lark-based admin approve/reject for transfers above the single-tx cap.
- Disabled by default; opt-in via new `approval` / `priceFeed` config blocks and per-cashier `windowValueLimit` / `singleTxValueLimit`. Existing chain configs are unchanged.
- Fails closed: if the guard cannot evaluate a transfer (missing/stale price, missing token metadata, transient errors) signing is paused for that transfer rather than allowed through. Dedup'd Lark alerts (10 min) keep noise bounded.
- One-shot decision semantics: in-memory decision lock when pending state is present (first-responder wins), with a DB-only fallback after a witness restart so admin clicks still work; `UPDATE ... WHERE status='approval'` provides atomicity. `cb.Cashier` is used only for routing; SQL `WHERE` always uses the guard's bound cashier key.

### 2. Stale-height alert + mute (source data deleted)
When the relayer reports a stale block height the witness can no longer fetch (source chain/API pruned that history), the witness used to abort `ProcessStales` on the first failure — blocking every later stale height behind it and re-logging every tick.
- `ProcessStales` now **skips-and-continues** past un-fetchable heights, and posts a **Lark warning card with a Mute button** (cashier + height). Muting records the height **in-memory** in the per-cashier `ApprovalGuard`, so it's skipped on later ticks and stops alerting. Falls back to a deduplicated text alert when no guard/card webhook is configured.
- Alerts fire only for heights **at/below the witness tip**; a height above the tip means the witness is still catching up (not missing data) and is skipped silently to avoid false "data deleted" pages on restart.
- Current vs. previous-cashier heights are attributed correctly in the card; the Mute button still routes back to the posting guard via `LarkStaleWarning.GuardKey`.
- Admins resolve the transfer out-of-band with `sign-witness` / `submit-witness` (no API fetch needed). New runbook: `witness-service/docs/missing-transaction-runbook.md` (find → sign → submit → mute).

## Changes
- `witness/approval.go` — guard core, `Check`, `RequestApproval`, `Approve`/`Reject`, nonce/replay protection; stale-height mute state + `IsHeightMuted` / `NotifyStaleFetchFailure` / `Mute` (dedup map pruned on insert)
- `witness/approval_server.go` — HTTP callback handler with HMAC-SHA256 signature verify and replay protection; `mute` action
- `util/lark_card.go` — interactive approval + stale-warning card senders (shared `postLarkInteractiveCard` poster), signature verifier, `uint64FromValue` parse helper
- `util/coingecko.go` — cached CoinGecko price source with refresh loop and max-age
- `witness/recorder.go` — `SignedAmountSince`, `MarkTransferAwaitingApproval`, `ApproveTransfer`, `RejectTransfer`
- `witness/types.go` — `TransferAwaitingApproval`, `TransferApproved`, `TransferRejected` statuses
- `witness/tokencashierbase.go` — integrate guard before signing; rework `ProcessStales` (skip muted, skip-and-continue, tip-aware alerting)
- `cmd/witness/main.go` — wire config, price feed, and approval server
- `docs/missing-transaction-runbook.md` — admin runbook for missing/deleted source transactions

## Test plan
- [x] `go build ./witness-service/...`
- [x] `go test ./witness-service/...` (all pass; includes guard mute/dedup, Lark card decode/send, approval-server mute path)
- [ ] Manual: enable on a non-prod cashier, set a low single-tx limit, confirm Lark card delivery and approve/reject flow
- [ ] Manual: restart witness while a transfer is in `approval` state, verify admin click still resolves it via DB-fallback path
- [ ] Manual: simulate stale price feed, verify signing pauses with deduplicated alerts and resumes once price refreshes
- [ ] Manual: point a witness at a stale height with no node data, confirm one Lark warning card, click Mute, confirm it no longer alerts next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)
