### PR TITLE
witness-service: simplify in-place upgrades

### DIFF
--- a/witness-service/docker-compose-witness.yml
+++ b/witness-service/docker-compose-witness.yml
@@ -1,5 +1,8 @@
 version: '2'
 
+# The witness image tag is controlled by WITNESS_TAG in .env (defaults to latest).
+# Upgrade in place with:  ./upgrade.sh   (i.e. docker compose pull && docker compose up -d)
+
 services:
   database:
     container_name: witness-db
@@ -14,7 +17,7 @@ services:
 
   iotex-payload-witness:
     container_name: iotex-payload-witness
-    image: witness:latest
+    image: ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}
     restart: on-failure
     volumes:
       - $IOTEX_WITNESS/etc/witness-config-iotex-payload.yaml:/etc/iotube-witness/witness-config-iotex-payload.yaml:ro
@@ -27,7 +30,7 @@ services:
 
 #   ethereum-payload-witness:
 #     container_name: ethereum-payload-witness
-#     image: witness:latest
+#     image: ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}
 #     restart: on-failure
 #     volumes:
 #       - $IOTEX_WITNESS/etc/witness-config-ethereum-payload.yaml:/etc/iotube-witness/witness-config-ethereum-payload.yaml:ro
@@ -40,7 +43,7 @@ services:
 
   bsc-payload-witness:
     container_name: bsc-payload-witness
-    image: witness:latest
+    image: ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}
     restart: on-failure
     volumes:
       - $IOTEX_WITNESS/etc/witness-config-bsc-payload.yaml:/etc/iotube-witness/witness-config-bsc-payload.yaml:ro
@@ -53,7 +56,7 @@ services:
 
   matic-payload-witness:
     container_name: matic-payload-witness
-    image: witness:latest
+    image: ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}
     restart: on-failure
     volumes:
       - $IOTEX_WITNESS/etc/witness-config-matic-payload.yaml:/etc/iotube-witness/witness-config-matic-payload.yaml:ro
@@ -66,7 +69,7 @@ services:
 
 #   solana-witness:
 #     container_name: solana-witness
-#     image: witness:latest
+#     image: ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}
 #     restart: on-failure
 #     volumes:
 #       - $IOTEX_WITNESS/etc/witness-config-solana.yaml:/etc/iotube-witness/witness-config-solana.yaml:ro
@@ -79,7 +82,7 @@ services:
   
 #   iotex-solana-witness:
 #     container_name: iotex-solana-witness
-#     image: witness:latest
+#     image: ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}
 #     restart: on-failure
 #     volumes:
 #       - $IOTEX_WITNESS/etc/witness-config-iotex-solana.yaml:/etc/iotube-witness/witness-config-iotex-solana.yaml:ro

--- a/witness-service/start_witness.sh
+++ b/witness-service/start_witness.sh
@@ -161,8 +161,16 @@ function grantPrivileges() {
 
 function buildService() {
     local envFile="${IOTEX_WITNESS}/etc/.env"
-    [[ -f "$envFile" ]] && source "$envFile"
-    docker pull ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest} || exit 2
+    # Read only WITNESS_TAG from .env. Do NOT source the whole file: this runs
+    # before downloadConfigFile normalizes .env, so a template-seeded file with
+    # empty IOTEX_WITNESS= / DB_ROOT_PASSWORD= would clobber the already-computed
+    # data dir (-> operating under /etc) and DB password (-> blank MySQL root).
+    if [[ -f "$envFile" ]]; then
+        local tag
+        tag=$(sed -n 's/^[[:space:]]*WITNESS_TAG=//p' "$envFile" | tail -1)
+        [[ -n "$tag" ]] && WITNESS_TAG="$tag"
+    fi
+    docker pull "ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}" || exit 2
 }
 
 function startup() {

--- a/witness-service/start_witness.sh
+++ b/witness-service/start_witness.sh
@@ -166,8 +166,20 @@ function buildService() {
     # empty IOTEX_WITNESS= / DB_ROOT_PASSWORD= would clobber the already-computed
     # data dir (-> operating under /etc) and DB password (-> blank MySQL root).
     if [[ -f "$envFile" ]]; then
-        local tag
-        tag=$(sed -n 's/^[[:space:]]*WITNESS_TAG=//p' "$envFile" | tail -1)
+        local line tag
+        line=$(grep -E '^[[:space:]]*WITNESS_TAG=' "$envFile" | tail -1)
+        tag=${line#*=}
+        tag=${tag%$'\r'}                        # strip trailing CR
+        tag=${tag#"${tag%%[![:space:]]*}"}      # ltrim
+        # follow compose .env syntax: quoted value, or unquoted up to an inline
+        # comment (docker tags contain no whitespace, so take the first token).
+        if [[ $tag == \"*\"* ]]; then
+            tag=${tag#\"}; tag=${tag%%\"*}
+        elif [[ $tag == \'*\'* ]]; then
+            tag=${tag#\'}; tag=${tag%%\'*}
+        else
+            tag=${tag%%[[:space:]]*}
+        fi
         [[ -n "$tag" ]] && WITNESS_TAG="$tag"
     fi
     docker pull "ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}" || exit 2

--- a/witness-service/start_witness.sh
+++ b/witness-service/start_witness.sh
@@ -99,6 +99,9 @@ function downloadConfigFile() {
         mv ${envFile}.tmp $envFile
     fi
     echo "DB_ROOT_PASSWORD=$DB_ROOT_PASSWORD" >> ${envFile}
+    if ! grep -q "^WITNESS_TAG=" ${envFile}; then
+        echo "WITNESS_TAG=latest" >> ${envFile}
+    fi
     sed "/^$/d" ${envFile} > ${envFile}.tmp
     mv ${envFile}.tmp $envFile
     cp -f $PROJECT_ABS_DIR/crontab ${IOTEX_WITNESS}/etc/crontab
@@ -157,8 +160,9 @@ function grantPrivileges() {
  }
 
 function buildService() {
-    docker pull ghcr.io/iotubeproject/iotube-witness:latest || exit 2
-    docker tag ghcr.io/iotubeproject/iotube-witness:latest witness:latest
+    local envFile="${IOTEX_WITNESS}/etc/.env"
+    [[ -f "$envFile" ]] && source "$envFile"
+    docker pull ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest} || exit 2
 }
 
 function startup() {
@@ -166,7 +170,7 @@ function startup() {
     pushd $IOTEX_WITNESS/etc
     docker compose up -d
     docker compose restart
-    docker system prune -a
+    docker image prune -f
     if [ $? -eq 0 ];then
         echo -e "${YELLOW} Service on. ${NC}"
     fi

--- a/witness-service/upgrade.sh
+++ b/witness-service/upgrade.sh
@@ -3,9 +3,9 @@
 # Upgrade running witnesses in place.
 #
 # Pulls the witness image (pinned by WITNESS_TAG in .env, default: latest) and
-# recreates the containers. It does NOT re-copy config files and does NOT run a
-# destructive image prune, so it is safe to run repeatedly and will not clobber
-# local edits.
+# recreates the witness containers. It does NOT re-copy config files and does
+# NOT run a destructive image prune, so it is safe to run repeatedly and will
+# not clobber local edits.
 #
 # For a config/route change (e.g. adding a new chain), refresh the repo first:
 #   git pull --recurse-submodules
@@ -17,19 +17,38 @@ set -euo pipefail
 
 defaultdatadir="$HOME/iotex-witness"
 IOTEX_WITNESS="${IOTEX_WITNESS:-$defaultdatadir}"
+COMPOSE_FILE="$IOTEX_WITNESS/etc/docker-compose.yml"
 
-if [[ ! -f "$IOTEX_WITNESS/etc/docker-compose.yml" ]]; then
+if [[ ! -f "$COMPOSE_FILE" ]]; then
     echo "No compose file at $IOTEX_WITNESS/etc — run ./start_witness.sh first." >&2
     exit 1
 fi
 
 cd "$IOTEX_WITNESS/etc"
 
-echo "Pulling witness image (WITNESS_TAG from .env, default: latest)..."
-docker compose pull
+# Migrate legacy installs: witnesses set up before the ghcr-image change have a
+# compose file that still names the old locally-retagged `witness:latest`, which
+# `docker compose pull` cannot fetch. Rewrite just the image lines to the pinned
+# ghcr reference (idempotent; preserves any route comment/uncomment edits).
+if grep -q '^[[:space:]]*image: witness:latest[[:space:]]*$' "$COMPOSE_FILE"; then
+    echo "Migrating legacy 'witness:latest' image references to ghcr..."
+    sed -i 's#image: witness:latest#image: ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}#' "$COMPOSE_FILE"
+fi
 
-echo "Recreating containers..."
-docker compose up -d
+# Only pull/recreate the witness services, never the database: an unqualified
+# `docker compose pull` would also pull the database service's floating `mysql:8`
+# tag, and the subsequent `up -d` would roll the production DB to a new digest.
+mapfile -t WITNESS_SERVICES < <(docker compose config --services | grep -v -x 'database')
+if [[ ${#WITNESS_SERVICES[@]} -eq 0 ]]; then
+    echo "No witness services found in $COMPOSE_FILE." >&2
+    exit 1
+fi
+
+echo "Pulling witness image (WITNESS_TAG from .env, default: latest)..."
+docker compose pull "${WITNESS_SERVICES[@]}"
+
+echo "Recreating witness containers..."
+docker compose up -d "${WITNESS_SERVICES[@]}"
 
 echo "Removing dangling images..."
 docker image prune -f

--- a/witness-service/upgrade.sh
+++ b/witness-service/upgrade.sh
@@ -35,12 +35,19 @@ if grep -q '^[[:space:]]*image: witness:latest[[:space:]]*$' "$COMPOSE_FILE"; th
     sed -i 's#image: witness:latest#image: ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}#' "$COMPOSE_FILE"
 fi
 
-# Only pull/recreate the witness services, never the database: an unqualified
-# `docker compose pull` would also pull the database service's floating `mysql:8`
-# tag, and the subsequent `up -d` would roll the production DB to a new digest.
-mapfile -t WITNESS_SERVICES < <(docker compose config --services | grep -v -x 'database')
+# Only pull/recreate the services that run the witness image. Selecting by image
+# (rather than "every service except database") keeps a witness upgrade from also
+# pulling/recreating the optional cron/backup helpers' floating Docker Hub images
+# if an operator has uncommented them, and never touches the database.
+mapfile -t ALL_SERVICES < <(docker compose config --services)
+WITNESS_SERVICES=()
+for svc in "${ALL_SERVICES[@]}"; do
+    if docker compose config --images "$svc" 2>/dev/null | grep -q 'iotube-witness'; then
+        WITNESS_SERVICES+=("$svc")
+    fi
+done
 if [[ ${#WITNESS_SERVICES[@]} -eq 0 ]]; then
-    echo "No witness services found in $COMPOSE_FILE." >&2
+    echo "No witness services (ghcr.io/iotubeproject/iotube-witness) found in $COMPOSE_FILE." >&2
     exit 1
 fi
 

--- a/witness-service/upgrade.sh
+++ b/witness-service/upgrade.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Upgrade running witnesses in place.
+#
+# Pulls the witness image (pinned by WITNESS_TAG in .env, default: latest) and
+# recreates the containers. It does NOT re-copy config files and does NOT run a
+# destructive image prune, so it is safe to run repeatedly and will not clobber
+# local edits.
+#
+# For a config/route change (e.g. adding a new chain), refresh the repo first:
+#   git pull --recurse-submodules
+#   ./start_witness.sh          # re-copies config templates, then (re)starts
+#
+# Usage:  ./upgrade.sh
+#
+set -euo pipefail
+
+defaultdatadir="$HOME/iotex-witness"
+IOTEX_WITNESS="${IOTEX_WITNESS:-$defaultdatadir}"
+
+if [[ ! -f "$IOTEX_WITNESS/etc/docker-compose.yml" ]]; then
+    echo "No compose file at $IOTEX_WITNESS/etc — run ./start_witness.sh first." >&2
+    exit 1
+fi
+
+cd "$IOTEX_WITNESS/etc"
+
+echo "Pulling witness image (WITNESS_TAG from .env, default: latest)..."
+docker compose pull
+
+echo "Recreating containers..."
+docker compose up -d
+
+echo "Removing dangling images..."
+docker image prune -f
+
+echo "Done. Current status:"
+docker compose ps


### PR DESCRIPTION
## Why

Upgrading a running witness is more painful than it should be. Today the flow is
`git pull` → re-run `start_witness.sh`, which:

1. pulls `ghcr.io/iotubeproject/iotube-witness:latest` and **retags** it to a
   local `witness:latest` tag that the compose file references — so you cannot
   just `docker compose pull`;
2. re-copies every config template (clobbering local edits); and
3. runs `docker system prune -a`, which **deletes the image**, forcing a full
   re-pull on the next run.

On top of that, `:latest` everywhere means no operator knows which build they
are actually running, and there is no clean rollback.

## What changed

- **Point compose at the ghcr image directly**, tag-pinned via `WITNESS_TAG` in
  `.env` (defaults to `latest`):
  `image: ghcr.io/iotubeproject/iotube-witness:${WITNESS_TAG:-latest}`.
  No more pull+retag indirection; pinning a tag makes releases deterministic and
  rollback a one-line `.env` change + `up -d`.
- **Soften the prune**: `docker system prune -a` → `docker image prune -f`
  (dangling only) in `startup()`, so upgrades stop deleting the running image.
- **Seed `WITNESS_TAG=latest`** into `.env` on setup, preserving an operator's
  existing pin.
- **Add `upgrade.sh`**: `docker compose pull && docker compose up -d` with no
  config re-copy and no aggressive prune — safe to run repeatedly.

A code/image upgrade is now just:

```
git pull --recurse-submodules && ./upgrade.sh
```

## Notes

- Runtime topology is unchanged — same services, same configs, same env vars.
- The commented-out image lines were updated too, so uncommenting a future route
  stays consistent.
- Follow-up (not in this PR): replace the comment/uncomment pattern for enabling
  routes with compose `profiles:` + `COMPOSE_PROFILES` in `.env`, so operators
  never hand-edit the compose YAML.