### PR TITLE
relayer: order the List API by source blockHeight, not creationTime

### DIFF
--- a/witness-service/relayer/recorder.go
+++ b/witness-service/relayer/recorder.go
@@ -648,8 +648,14 @@ func (recorder *Recorder) TransfersWithFBO(
 ) ([]*Transfer, error) {
 	recorder.mutex.RLock()
 	defer recorder.mutex.RUnlock()
+	// Order the user-facing List by blockHeight (the source-chain block, i.e. the
+	// real transfer time) rather than creationTime (when the row was inserted on
+	// this relayer). Re-submitting an old transfer stamps a fresh creationTime and
+	// would otherwise jump it to the top of the list; each payload relayer serves a
+	// single source chain, so blockHeight is monotonic in real time here.
 	return recorder.transfers(
 		fmt.Sprintf("SELECT `cashier`, IFNULL(`fbo_token`, `token`), `tidx`, `sender`, `txSender`, IFNULL(`fbo_recipient`, `recipient`), `amount`, `payload`, `fee`, `id`, `txHash`, `txTimestamp`, `nonce`, `gas`, `gasPrice`, `status`, `updateTime`, `relayer` FROM %s", recorder.transferTableName),
+		"blockHeight",
 		offset,
 		limit,
 		desc,
@@ -666,8 +672,10 @@ func (recorder *Recorder) Transfers(
 ) ([]*Transfer, error) {
 	recorder.mutex.RLock()
 	defer recorder.mutex.RUnlock()
+	// Internal processing (bonus/confirm/submit queues) keeps creationTime ordering.
 	return recorder.transfers(
 		fmt.Sprintf("SELECT `cashier`, `token`, `tidx`, `sender`, `txSender`, `recipient`, `amount`, `payload`, `fee`, `id`, `txHash`, `txTimestamp`, `nonce`, `gas`, `gasPrice`, `status`, `updateTime`, `relayer` FROM %s", recorder.transferTableName),
+		"creationTime",
 		offset,
 		limit,
 		desc,
@@ -677,12 +685,12 @@ func (recorder *Recorder) Transfers(
 
 func (recorder *Recorder) transfers(
 	query string,
+	orderBy string,
 	offset uint32,
 	limit uint8,
 	desc Order,
 	queryOpts []TransferQueryOption,
 ) ([]*Transfer, error) {
-	orderBy := "creationTime"
 	params := []interface{}{}
 	queryOpts = append(queryOpts, ExcludeAmountZeroOption())
 	conditions := []string{}


### PR DESCRIPTION
## Problem

The user-facing `List` API (bridge \"recent transactions\") sorts by `creationTime` — the time the row was inserted on **this** relayer. When an old transfer is re-submitted (e.g. a witness replays a months-old stuck transfer), its `creationTime` is stamped to *now*, so it jumps to the **top** of the list as if it were brand new.

Concrete case: a CYC iotex→bsc transfer from **2026-02-24** (source block 45,404,188) was re-submitted today and appeared as the newest item on the frontend, because its relayer `creationTime` was today.

## Fix

Order the `List` path (`TransfersWithFBO`) by **`blockHeight`** (the source-chain block = the real transfer time) instead of `creationTime`. Each payload relayer serves a single source chain, so `blockHeight` is monotonic in real time within an endpoint, and re-submitted old transfers sort back to their true position.

- `orderBy` is now a parameter of the private `transfers()` helper.
- Internal processing queues (bonus / confirm / submit, via `Transfers()`) keep `creationTime` ordering — only the List path changes.
- Neither column is indexed, so this is perf-neutral (the List already filesorted on `creationTime`).

## Follow-up (not in this PR)

The `List` response returns `txTimestamp`, which is **also** the re-insert time — so the displayed date for a re-submitted old transfer is still wrong. Exposing the real source-block timestamp (resolve `blockHeight`→time at ingest, add to the response proto) is a separate, larger change.