### PR TITLE
ci: build and publish the iotube-relayer image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Witness Image
+name: Build and Publish Witness and Relayer Images
 
 on:
   push:
@@ -58,4 +58,53 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          
+
+  # Separate job so the witness image (which others depend on) is never disturbed.
+  # Same module, different entrypoint (Dockerfile.relayer builds cmd/relayer); own
+  # cache scope so it doesn't collide with the witness build.
+  build-relayer:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/iotubeproject/iotube-relayer
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          context: ./witness-service
+          file: ./witness-service/Dockerfile.relayer
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=relayer
+          cache-to: type=gha,mode=max,scope=relayer


### PR DESCRIPTION
## Why

The relayer is the **same Go module** as the witness — only a different entrypoint (`cmd/relayer`, built by `Dockerfile.relayer`). But CI (`docker-publish.yml`) only builds and publishes the **witness** image, so the relayer has been **hand-built and tagged locally** (e.g. a stale `relayer:v0522` on the deploy host). That makes relayer redeploys manual and error-prone, and there's no way to pull a known-good relayer image.

## What

Add a separate `build-relayer` job that builds `Dockerfile.relayer` and pushes `ghcr.io/iotubeproject/iotube-relayer`.

- **Separate job, not a matrix** — the existing witness `build` job (which others depend on) is left completely untouched.
- **Own gha cache scope** (`scope=relayer`) so it doesn't collide with the witness build cache.
- Adds a `type=sha` tag so deployments can pin to an exact commit.
- PRs build but don't push (same `push: ${{ github.event_name != 'pull_request' }}` guard as the witness job).

After merge, deploying the relayer becomes `docker pull ghcr.io/iotubeproject/iotube-relayer:<tag>` — same flow as the witness, no more local builds.