### PR TITLE
relayer: verify witness membership at ingest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,9 @@ typechain-types
 cache
 artifacts
 bun.lockb
+
+# Foundry build output
+out
+broadcast
 # Witness signing tools binaries
 witness-service/bin/

--- a/witness-service/relayer/service.go
+++ b/witness-service/relayer/service.go
@@ -138,6 +138,13 @@ func (s *Service) submit(w *types.Witness) ([]byte, error) {
 		if err := validateSignature(transfer.id.Bytes(), common.BytesToAddress(w.Address), w.Signature); err != nil {
 			return nil, err
 		}
+		// Reject signatures from addresses that are not registered on-chain witnesses,
+		// so forged/junk submissions never enter the DB. Fail open when the witness
+		// set has not been loaded from chain yet — the on-chain validator is still the
+		// ultimate gate for settlement.
+		if member, loaded := validator.IsActiveWitness(common.BytesToAddress(w.Address)); loaded && !member {
+			return nil, errors.Errorf("rejecting submission from non-witness %s", common.BytesToAddress(w.Address).Hex())
+		}
 		witness, err = NewWitness(w.Address, w.Signature)
 		if err != nil {
 			return nil, err

--- a/witness-service/relayer/transfervalidatoronethereum.go
+++ b/witness-service/relayer/transfervalidatoronethereum.go
@@ -51,6 +51,14 @@ type (
 		validator           validatorContract
 		witnessListContract *contract.AddressListCaller
 		witnesses           map[string]bool
+		// lastWitnessRefresh is the time of the last *successful* on-chain load;
+		// drives the fail-open "genuinely not a member" decision in IsActiveWitness.
+		lastWitnessRefresh time.Time
+		// lastWitnessRefreshAttempt is the time of the last refresh *attempt*
+		// (success or failure); rate-limits the on-miss refresh so a stream of junk
+		// submissions (Submit is unauthenticated) can't force a chain RPC every call,
+		// even while the RPC is erroring and lastWitnessRefresh stays stale.
+		lastWitnessRefreshAttempt time.Time
 	}
 
 	validatorContract interface {
@@ -298,6 +306,10 @@ func (tv *transferValidatorOnEthereum) Address() common.Address {
 }
 
 func (tv *transferValidatorOnEthereum) refresh() error {
+	// Stamp the attempt up front (caller holds tv.mu) so the on-miss rate limit in
+	// IsActiveWitness backs off even when the RPC below errors and we never reach
+	// the success stamp.
+	tv.lastWitnessRefreshAttempt = time.Now()
 	callOpts, err := tv.callOpts()
 	if err != nil {
 		return err
@@ -326,6 +338,7 @@ func (tv *transferValidatorOnEthereum) refresh() error {
 	}
 
 	tv.witnesses = activeWitnesses
+	tv.lastWitnessRefresh = time.Now()
 	return nil
 }
 
@@ -333,6 +346,50 @@ func (tv *transferValidatorOnEthereum) isActiveWitness(witness common.Address) b
 	val, ok := tv.witnesses[witness.Hex()]
 
 	return ok && val
+}
+
+// witnessRefreshCooldown bounds how often IsActiveWitness re-queries the on-chain
+// witness set on a miss, so junk addresses can't spam refresh RPCs.
+const witnessRefreshCooldown = 30 * time.Second
+
+// IsActiveWitness reports whether addr is in the on-chain registered witness set,
+// and whether that set is currently loaded. When the cached set is stale it refreshes
+// from chain once (rate-limited to once per witnessRefreshCooldown, shared with the
+// refresh done during submission) before trusting either verdict, so both additions
+// and removals to the on-chain set are reflected. If the refresh fails or is rate-
+// limited away, a non-membership result returns loaded==false; callers should treat
+// loaded==false as "unknown" and fail open (the on-chain validator is the ultimate
+// gate). Safe for concurrent use.
+func (tv *transferValidatorOnEthereum) IsActiveWitness(addr common.Address) (isMember bool, loaded bool) {
+	hexAddr := addr.Hex()
+	tv.mu.RLock()
+	_, member := tv.witnesses[hexAddr]
+	fresh := len(tv.witnesses) > 0 && !tv.lastWitnessRefresh.IsZero() &&
+		time.Since(tv.lastWitnessRefresh) <= witnessRefreshCooldown
+	tv.mu.RUnlock()
+	if fresh {
+		// Cache is current; trust the hit or the miss without another chain call.
+		return member, true
+	}
+	// Stale or never loaded: refresh once (rate-limited by the last refresh attempt,
+	// not the last success, so a failing RPC still backs off) and re-check.
+	tv.mu.Lock()
+	if tv.lastWitnessRefreshAttempt.IsZero() ||
+		time.Since(tv.lastWitnessRefreshAttempt) > witnessRefreshCooldown {
+		if err := tv.refresh(); err != nil {
+			log.Printf("failed to refresh witness set: %v\n", err)
+		}
+	}
+	_, member = tv.witnesses[hexAddr]
+	fresh = len(tv.witnesses) > 0 && !tv.lastWitnessRefresh.IsZero() &&
+		time.Since(tv.lastWitnessRefresh) <= witnessRefreshCooldown
+	tv.mu.Unlock()
+	if member {
+		return true, true
+	}
+	// Only a fresh, successful load makes a non-membership verdict authoritative;
+	// otherwise report unknown so the caller falls back to the on-chain gate.
+	return false, fresh
 }
 
 // Check returns true if a transfer has been settled

--- a/witness-service/relayer/types.go
+++ b/witness-service/relayer/types.go
@@ -73,6 +73,9 @@ type (
 		Address() common.Address
 		// Check returns transfer status on chain
 		Check(transfer *Transfer) (StatusOnChainType, error)
+		// IsActiveWitness reports whether addr is a registered on-chain witness,
+		// and whether the witness set has been loaded from chain yet.
+		IsActiveWitness(addr common.Address) (isMember bool, loaded bool)
 		// Submit submits validation for a transfer
 		Submit(transfer *Transfer, witnesses []*Witness) (common.Hash, common.Address, uint64, *big.Int, error)
 		// SpeedUp resubmits validation with higher gas price


### PR DESCRIPTION
## What

`Service.submit()` now verifies the recovered signer against the cached on-chain
witness set before a transfer is persisted, via a new
`IsActiveWitness(addr) -> (isMember, loaded)` on the `TransferValidator` interface.
Submissions from addresses outside the current witness set are not recorded.

The cached set is refreshed from chain (rate-limited) when stale, so both additions
and removals to the on-chain set are reflected. The check is **fail-open**: if
membership can't be confirmed (cold start or a refresh error) the submission is
accepted — the on-chain `TransferValidator` remains the authoritative gate, so this
never trades availability.

Scoped to the EVM validator path. Also gitignores Foundry `out/` / `broadcast/`.