### PR TITLE
witness-service: fail fast when required compose env vars are unset

### DIFF
--- a/witness-service/.env.template
+++ b/witness-service/.env.template
@@ -1,4 +1,25 @@
-RELAYER_URL=
-WITNESS_PRIVATE_KEY=
+# Witness deploy configuration.
+# Copy this file to `.env` in the same directory as docker-compose-witness.yml,
+# then fill in the values. docker compose reads `.env` automatically.
+#
+# The two REQUIRED values below are guarded in the compose file: if either is left
+# blank, `docker compose up` fails immediately telling you which one to set,
+# instead of silently mounting empty dirs over the config files and crash-looping.
+
+# REQUIRED. Absolute path to the witness deploy directory. Must contain `etc/`
+# (the witness-config-*.yaml files) and `data/` (the MySQL data dir).
+# Example: IOTEX_WITNESS=/home/deploy/iotex-witness
 IOTEX_WITNESS=
+
+# REQUIRED. MySQL root password for the local witness-db container.
 DB_ROOT_PASSWORD=
+
+# Optional. Witness image tag to run; defaults to `latest` when unset.
+# Pin to a specific build for reproducible upgrades, e.g. WITNESS_TAG=sha-2426738
+WITNESS_TAG=latest
+
+# Optional. Only needed if you inject the witness signing key / relayer address via
+# environment variables instead of the *.secret.yaml files. Leave blank when using
+# file-based secrets (the recommended setup).
+WITNESS_PRIVATE_KEY=
+RELAYER_URL=

--- a/witness-service/README.md
+++ b/witness-service/README.md
@@ -6,6 +6,9 @@
 
 1. go to the working directory of this repo, and then go into `witness-service` directory
 2. create a path at `~/iotex-witness/etc`
-3. copy .env.template `~/iotex-witness/etc/.env`, and set values
+3. copy `.env.template` to `.env` and set values — at minimum the two REQUIRED
+   vars `IOTEX_WITNESS` (absolute deploy path) and `DB_ROOT_PASSWORD`. If either is
+   left blank, `docker compose` fails fast and tells you which one to set (rather
+   than silently mounting empty dirs over the config files).
 4. set `clientURL` in `witness-config-ethereum.secret.yaml`
 5. run `./start_witness.sh` to build and start running services.

--- a/witness-service/docker-compose-relayer.yml
+++ b/witness-service/docker-compose-relayer.yml
@@ -1,5 +1,11 @@
 version: '2'
 
+# Required .env values (copy .env.template -> .env next to this file, then fill in):
+#   IOTEX_RELAYER    - absolute path to the relayer deploy dir (holds etc/ and data/)
+#   DB_ROOT_PASSWORD - MySQL root password for the local relayer-db
+# If either is unset, docker compose fails fast with a clear message (the ${VAR:?...}
+# guards below) instead of silently mounting empty directories over the config files.
+
 services:
   database:
     container_name: relayer-db
@@ -8,9 +14,9 @@ services:
     ports:
       - 13306:3306
     volumes:
-      - $IOTEX_RELAYER/data/mysql:/var/lib/mysql:rw
+      - "${IOTEX_RELAYER:?IOTEX_RELAYER is unset - copy .env.template to .env and set it (see witness-service/README.md)}/data/mysql:/var/lib/mysql:rw"
     environment:
-       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD:?DB_ROOT_PASSWORD is unset - copy .env.template to .env and set it (see witness-service/README.md)}"
 
   iotex-payload-relayer:
     container_name: iotex-payload-relayer

--- a/witness-service/docker-compose-witness.yml
+++ b/witness-service/docker-compose-witness.yml
@@ -2,6 +2,12 @@ version: '2'
 
 # The witness image tag is controlled by WITNESS_TAG in .env (defaults to latest).
 # Upgrade in place with:  ./upgrade.sh   (i.e. docker compose pull && docker compose up -d)
+#
+# Required .env values (copy .env.template -> .env next to this file, then fill in):
+#   IOTEX_WITNESS    - absolute path to the witness deploy dir (holds etc/ and data/)
+#   DB_ROOT_PASSWORD - MySQL root password for the local witness-db
+# If either is unset, docker compose fails fast with a clear message (the ${VAR:?...}
+# guards below) instead of silently mounting empty directories over the config files.
 
 services:
   database:
@@ -11,9 +17,9 @@ services:
     ports:
       - 13306:3306
     volumes:
-      - $IOTEX_WITNESS/data/mysql:/var/lib/mysql:rw
+      - "${IOTEX_WITNESS:?IOTEX_WITNESS is unset - copy .env.template to .env and set it (see witness-service/README.md)}/data/mysql:/var/lib/mysql:rw"
     environment:
-       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD:?DB_ROOT_PASSWORD is unset - copy .env.template to .env and set it (see witness-service/README.md)}"
 
   iotex-payload-witness:
     container_name: iotex-payload-witness


### PR DESCRIPTION
## Problem
Running the witness/relayer stack with `docker compose up -d` and an unpopulated `.env` silently breaks: `IOTEX_WITNESS` / `IOTEX_RELAYER` / `DB_ROOT_PASSWORD` are referenced with no default, so an unset value resolves to an empty string. Docker then auto-creates empty directories at the (now wrong) bind-mount source paths and mounts them over the config files, and the container crash-loops with a cryptic `error applying options: read ...: is a directory`.

## Fix
- Guard the required vars in both compose files with `${VAR:?<message>}`, so `docker compose` fails immediately with an actionable message naming the missing var — instead of silently mounting empty dirs over the configs.
- Flesh out `.env.template` with per-var comments (required vs optional, examples, `WITNESS_TAG` default).
- Clarify the deploy step in `README.md`.

## Test
`docker compose config` with the vars unset now exits non-zero with `IOTEX_WITNESS is unset - copy .env.template to .env and set it (...)`; with the vars set it parses normally (all services resolve).