### PR TITLE
witness-service: source DB password from DB_PASSWORD env, drop hardcoded default

### DIFF
--- a/witness-service/backup_relayer
+++ b/witness-service/backup_relayer
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+# The DB password comes from the DB_ROOT_PASSWORD env var (set by the compose
+# service); MYSQL_PWD keeps it out of the process argument list.
 now=$(date +"%s_%Y-%m-%d")
-/usr/bin/mysqldump --opt -h 127.0.0.1 -u root -pkdfjjrU64fjK58H relayer > "/backup/${now}_relayer.sql"
+MYSQL_PWD="${DB_ROOT_PASSWORD}" /usr/bin/mysqldump --opt -h 127.0.0.1 -u root relayer > "/backup/${now}_relayer.sql"

--- a/witness-service/backup_witness
+++ b/witness-service/backup_witness
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+# The DB password comes from the DB_ROOT_PASSWORD env var (set by the compose
+# service); MYSQL_PWD keeps it out of the process argument list.
 now=$(date +"%s_%Y-%m-%d")
-/usr/bin/mysqldump --opt -h 127.0.0.1 -u root -pkdfjjrU64fjK58H witness > "/backup/${now}_witness.sql"
+MYSQL_PWD="${DB_ROOT_PASSWORD}" /usr/bin/mysqldump --opt -h 127.0.0.1 -u root witness > "/backup/${now}_witness.sql"

--- a/witness-service/clean-all.sh
+++ b/witness-service/clean-all.sh
@@ -7,7 +7,6 @@ NC='\033[0m' # No Color
 
 defaultdatadir="$HOME/iotex-witness"
 CURL="curl -Ss"
-DB_ROOT_PASSWORD="kdfjjrU64fjK58H"
 PROJECT_ABS_DIR=$(cd "$(dirname "$0")";pwd)
 
 pushd () {

--- a/witness-service/docker-compose-relayer.yml
+++ b/witness-service/docker-compose-relayer.yml
@@ -32,6 +32,7 @@ services:
     command: relayer -config=/etc/iotube-relayer/relayer-config-iotex-payload.yaml
     environment:
       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
 #   ethereum-payload-relayer:
 #     container_name: ethereum-payload-relayer
@@ -62,6 +63,7 @@ services:
     command: relayer -config=/etc/iotube-relayer/relayer-config-bsc-payload.yaml
     environment:
       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
 #   matic-payload-relayer:
 #     container_name: matic-payload-relayer

--- a/witness-service/docker-compose-testnet-relayer.yml
+++ b/witness-service/docker-compose-testnet-relayer.yml
@@ -13,6 +13,7 @@ services:
     command: relayer -config=/etc/iotube-relayer/relayer-config-iotex-testnet.yaml
     environment:
       RELAYER_PRIVATE_KEY: ${TESTNET_RELAYER_PRIVATE_KEY}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
   sepolia-relayer:
     container_name: sepolia-relayer
@@ -26,6 +27,7 @@ services:
     command: relayer -config=/etc/iotube-relayer/relayer-config-sepolia.yaml
     environment:
       RELAYER_PRIVATE_KEY: ${TESTNET_RELAYER_PRIVATE_KEY}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
   bsc-testnet-relayer:
     container_name: bsc-testnet-relayer
@@ -39,4 +41,5 @@ services:
     command: relayer -config=/etc/iotube-relayer/relayer-config-bsc-testnet.yaml
     environment:
       RELAYER_PRIVATE_KEY: ${TESTNET_RELAYER_PRIVATE_KEY}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 

--- a/witness-service/docker-compose-testnet-witness.yml
+++ b/witness-service/docker-compose-testnet-witness.yml
@@ -12,6 +12,7 @@ services:
     command: witness -config=/etc/iotube-witness/witness-config-iotex-testnet.yaml -secret=/etc/iotube-witness/witness-config-iotex-testnet.secret.yaml
     environment:
       WITNESS_PRIVATE_KEY: ${TESTNET_WITNESS_PRIVATE_KEY}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       RELAYER_URL: ${RELAYER_URL}
 
   sepolia-witness:
@@ -25,6 +26,7 @@ services:
     command: witness -config=/etc/iotube-witness/witness-config-sepolia.yaml -secret=/etc/iotube-witness/witness-config-sepolia.secret.yaml
     environment:
       WITNESS_PRIVATE_KEY: ${TESTNET_WITNESS_PRIVATE_KEY}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       RELAYER_URL: ${RELAYER_URL}
 
   bsc-testnet-witness:
@@ -38,5 +40,6 @@ services:
     command: witness -config=/etc/iotube-witness/witness-config-bsc-testnet.yaml -secret=/etc/iotube-witness/witness-config-bsc-testnet.secret.yaml
     environment:
       WITNESS_PRIVATE_KEY: ${TESTNET_WITNESS_PRIVATE_KEY}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       RELAYER_URL: ${RELAYER_URL}
 

--- a/witness-service/docker-compose-witness.yml
+++ b/witness-service/docker-compose-witness.yml
@@ -33,6 +33,7 @@ services:
     environment:
       WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
       RELAYER_URL: ${RELAYER_URL}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
 #   ethereum-payload-witness:
 #     container_name: ethereum-payload-witness
@@ -59,6 +60,7 @@ services:
     environment:
       WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
       RELAYER_URL: ${RELAYER_URL}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
   matic-payload-witness:
     container_name: matic-payload-witness
@@ -72,6 +74,7 @@ services:
     environment:
       WITNESS_PRIVATE_KEY: ${WITNESS_PRIVATE_KEY}
       RELAYER_URL: ${RELAYER_URL}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
 #   solana-witness:
 #     container_name: solana-witness

--- a/witness-service/start_relayer.sh
+++ b/witness-service/start_relayer.sh
@@ -7,7 +7,7 @@ NC='\033[0m' # No Color
 
 defaultdatadir="$HOME/iotex-relayer"
 CURL="curl -Ss"
-DB_ROOT_PASSWORD="kdfjjrU64fjK58H"
+DB_ROOT_PASSWORD="${DB_ROOT_PASSWORD:-}"   # no hardcoded default; resolveDbPassword() fills this in
 PROJECT_ABS_DIR=$(cd "$(dirname "$0")";pwd)
 
 pushd () {
@@ -90,6 +90,17 @@ function makeWorkspace() {
     downloadConfigFile
 }
 
+function resolveDbPassword() {
+    local envFile="${IOTEX_RELAYER}/etc/.env"
+    if [[ -z "$DB_ROOT_PASSWORD" && -f "$envFile" ]]; then
+        DB_ROOT_PASSWORD=$(grep -E '^DB_ROOT_PASSWORD=' "$envFile" | tail -1 | cut -d= -f2- | tr -d '\r')
+    fi
+    if [[ -z "$DB_ROOT_PASSWORD" ]]; then
+        DB_ROOT_PASSWORD=$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)
+        echo -e "${YELLOW} Generated a new random DB password for the local database. ${NC}"
+    fi
+}
+
 function exportAll() {
     export IOTEX_RELAYER DB_ROOT_PASSWORD PROJECT_ABS_DIR
 }
@@ -165,6 +176,7 @@ function main() {
 
     determinIotexRelayer
     confirmEnvironmentVariable
+    resolveDbPassword
 
     makeWorkspace
 

--- a/witness-service/start_testnet_relayer.sh
+++ b/witness-service/start_testnet_relayer.sh
@@ -7,7 +7,7 @@ NC='\033[0m' # No Color
 
 defaultdatadir="$HOME/iotex-relayer"
 CURL="curl -Ss"
-DB_ROOT_PASSWORD="kdfjjrU64fjK58H"
+DB_ROOT_PASSWORD="${DB_ROOT_PASSWORD:-}"   # no hardcoded default; resolveDbPassword() fills this in
 PROJECT_ABS_DIR=$(cd "$(dirname "$0")";pwd)
 
 pushd () {
@@ -96,6 +96,17 @@ function makeWorkspace() {
     downloadConfigFile
 }
 
+function resolveDbPassword() {
+    local envFile="${IOTEX_RELAYER}/etc/.env"
+    if [[ -z "$DB_ROOT_PASSWORD" && -f "$envFile" ]]; then
+        DB_ROOT_PASSWORD=$(grep -E '^DB_ROOT_PASSWORD=' "$envFile" | tail -1 | cut -d= -f2- | tr -d '\r')
+    fi
+    if [[ -z "$DB_ROOT_PASSWORD" ]]; then
+        DB_ROOT_PASSWORD=$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)
+        echo -e "${YELLOW} Generated a new random DB password for the local database. ${NC}"
+    fi
+}
+
 function exportAll() {
     export IOTEX_RELAYER DB_ROOT_PASSWORD PROJECT_ABS_DIR
 }
@@ -171,6 +182,7 @@ function main() {
 
     determinIotexRelayer
     confirmEnvironmentVariable
+    resolveDbPassword
 
     makeWorkspace
 

--- a/witness-service/start_testnet_witness.sh
+++ b/witness-service/start_testnet_witness.sh
@@ -7,7 +7,7 @@ NC='\033[0m' # No Color
 
 defaultdatadir="$HOME/iotex-witness"
 CURL="curl -Ss"
-DB_ROOT_PASSWORD="kdfjjrU64fjK58H"
+DB_ROOT_PASSWORD="${DB_ROOT_PASSWORD:-}"   # no hardcoded default; resolveDbPassword() fills this in
 PROJECT_ABS_DIR=$(cd "$(dirname "$0")";pwd)
 
 pushd () {
@@ -106,6 +106,17 @@ function makeWorkspace() {
     downloadConfigFile
 }
 
+function resolveDbPassword() {
+    local envFile="${IOTEX_WITNESS}/etc/.env"
+    if [[ -z "$DB_ROOT_PASSWORD" && -f "$envFile" ]]; then
+        DB_ROOT_PASSWORD=$(grep -E '^DB_ROOT_PASSWORD=' "$envFile" | tail -1 | cut -d= -f2- | tr -d '\r')
+    fi
+    if [[ -z "$DB_ROOT_PASSWORD" ]]; then
+        DB_ROOT_PASSWORD=$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)
+        echo -e "${YELLOW} Generated a new random DB password for the local database. ${NC}"
+    fi
+}
+
 function exportAll() {
     export IOTEX_WITNESS DB_ROOT_PASSWORD PROJECT_ABS_DIR
 }
@@ -184,6 +195,7 @@ function main() {
 
     determinIotexWitness
     confirmEnvironmentVariable
+    resolveDbPassword
 
     makeWorkspace
 

--- a/witness-service/start_witness.sh
+++ b/witness-service/start_witness.sh
@@ -7,7 +7,7 @@ NC='\033[0m' # No Color
 
 defaultdatadir="$HOME/iotex-witness"
 CURL="curl -Ss"
-DB_ROOT_PASSWORD="kdfjjrU64fjK58H"
+DB_ROOT_PASSWORD="${DB_ROOT_PASSWORD:-}"   # no hardcoded default; resolveDbPassword() fills this in
 PROJECT_ABS_DIR=$(cd "$(dirname "$0")";pwd)
 
 pushd () {
@@ -123,6 +123,17 @@ function makeWorkspace() {
     downloadConfigFile
 }
 
+function resolveDbPassword() {
+    local envFile="${IOTEX_WITNESS}/etc/.env"
+    if [[ -z "$DB_ROOT_PASSWORD" && -f "$envFile" ]]; then
+        DB_ROOT_PASSWORD=$(grep -E '^DB_ROOT_PASSWORD=' "$envFile" | tail -1 | cut -d= -f2- | tr -d '\r')
+    fi
+    if [[ -z "$DB_ROOT_PASSWORD" ]]; then
+        DB_ROOT_PASSWORD=$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)
+        echo -e "${YELLOW} Generated a new random DB password for the local database. ${NC}"
+    fi
+}
+
 function exportAll() {
     export IOTEX_WITNESS DB_ROOT_PASSWORD PROJECT_ABS_DIR
 }
@@ -222,6 +233,7 @@ function main() {
 
     determinIotexWitness
     confirmEnvironmentVariable
+    resolveDbPassword
 
     exportAll
 


### PR DESCRIPTION
## What

Companion to `iotubeproject/iotube-configs` (which changes `database.uri` to reference `${DB_ROOT_PASSWORD}`). This makes the deploy layer supply that variable to the app and stops shipping a hardcoded default DB password. **The env var name `DB_ROOT_PASSWORD` is unchanged**, so existing deployments keep working with their current `.env` whether they upgrade or not.

### Compose templates
- `docker-compose-{witness,relayer,testnet-witness,testnet-relayer}.yml`: pass `DB_ROOT_PASSWORD` into each witness/relayer service `environment:` so the `${DB_ROOT_PASSWORD}` placeholder in the config files expands at runtime. The `database` service already sources the same variable for `MYSQL_ROOT_PASSWORD`, so there is now a single source of truth per host.

### Bootstrap / helper scripts
- `start_{witness,relayer,testnet-witness,testnet-relayer}.sh`: remove the hardcoded default password. `resolveDbPassword()` resolves it in priority order: explicit environment value → existing `etc/.env` value → a freshly generated random password.
- `backup_{witness,relayer}`: read the password from `DB_ROOT_PASSWORD` via `MYSQL_PWD` instead of embedding it in the `mysqldump` argument list.
- `clean-all.sh`: drop the now-unused password variable.

## Non-breaking
- The `.env` key name is unchanged, so no host needs to touch its `.env`.
- Running services are unaffected (they use their host-local config already in place).
- On the next `start_*.sh` run, the new config + compose are copied together and the existing `.env` value is reused, so nothing changes for the operator.
- If `DB_ROOT_PASSWORD` is unset, `docker compose` fails fast via the existing `${DB_ROOT_PASSWORD:?...}` guard rather than starting with an empty password.

## Notes
- `bash -n` clean on all scripts; all four compose files parse as valid YAML with the passthrough on every active service.
