### PR TITLE
witness: finalized-block reorg protection (+ fix confirmBlockNumber uint8 overflow)

### DIFF
--- a/witness-service/cmd/witness/main.go
+++ b/witness-service/cmd/witness/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	"go.uber.org/config"
 
 	"github.com/iotexproject/ioTube/witness-service/db"
@@ -43,6 +44,7 @@ type Configuration struct {
 	SlackWebHook          string        `json:"slackWebHook" yaml:"slackWebHook"`
 	LarkWebHook           string        `json:"larkWebHook" yaml:"larkWebHook"`
 	ConfirmBlockNumber    int           `json:"confirmBlockNumber" yaml:"confirmBlockNumber"`
+	UseFinalizedBlock     bool          `json:"useFinalizedBlock" yaml:"useFinalizedBlock"`
 	BatchSize             int           `json:"batchSize" yaml:"batchSize"`
 	Interval              time.Duration `json:"interval" yaml:"interval"`
 	GrpcPort              int           `json:"grpcPort" yaml:"grpcPort"`
@@ -292,10 +294,11 @@ func main() {
 			cashiers = append(cashiers, cashier)
 		}
 	default: // "heco", "bsc", "matic", "polis", "iotex-e", "iotex", "sepolia", "iotex-testnet", "ethereum":
-		ethClient, err := ethclient.Dial(cfg.ClientURL)
+		rpcClient, err := rpc.Dial(cfg.ClientURL)
 		if err != nil {
 			log.Fatal(err)
 		}
+		ethClient := ethclient.NewClient(rpcClient)
 		for _, cc := range cfg.Cashiers {
 			var (
 				signHandler     witness.SignHandler
@@ -397,6 +400,7 @@ func main() {
 				version,
 				cc.RelayerURL,
 				ethClient,
+				rpcClient,
 				cashierAddr,
 				previousCashierAddr,
 				tokenSafeAddr,
@@ -411,7 +415,8 @@ func main() {
 					destAddrDecoder,
 				),
 				uint64(cc.StartBlockHeight),
-				uint8(cfg.ConfirmBlockNumber),
+				uint64(cfg.ConfirmBlockNumber),
+				cfg.UseFinalizedBlock,
 				signHandler,
 				reverseRecorder,
 				common.HexToAddress(cc.Reverse.CashierContractAddress),

--- a/witness-service/cmd/witness/main.go
+++ b/witness-service/cmd/witness/main.go
@@ -181,6 +181,12 @@ func main() {
 	if err := yaml.Get(config.Root).Populate(&cfg); err != nil {
 		log.Fatalln(err)
 	}
+	if cfg.ConfirmBlockNumber < 0 {
+		// ConfirmBlockNumber is passed to the witness as uint64; a negative
+		// value would wrap to a huge number, pinning the confirmed height to 0
+		// and producing perpetual regression errors. Fail fast instead.
+		log.Fatalf("confirmBlockNumber must be >= 0, got %d\n", cfg.ConfirmBlockNumber)
+	}
 	if pk, ok := os.LookupEnv("WITNESS_PRIVATE_KEY"); ok && cfg.PrivateKey == "" {
 		cfg.PrivateKey = pk
 	}
@@ -299,6 +305,17 @@ func main() {
 			log.Fatal(err)
 		}
 		ethClient := ethclient.NewClient(rpcClient)
+		if cfg.UseFinalizedBlock {
+			// Fail fast if the endpoint does not serve the "finalized" tag:
+			// otherwise every pull cycle would error and, after the grace
+			// window, the witness would silently stop submitting.
+			probeCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			if _, err := witness.ProbeFinalizedBlock(probeCtx, rpcClient); err != nil {
+				cancel()
+				log.Fatalf("useFinalizedBlock is enabled but RPC %s does not serve the finalized block tag: %v\n", cfg.ClientURL, err)
+			}
+			cancel()
+		}
 		for _, cc := range cfg.Cashiers {
 			var (
 				signHandler     witness.SignHandler

--- a/witness-service/witness/tokencashierbase.go
+++ b/witness-service/witness/tokencashierbase.go
@@ -201,6 +201,10 @@ func (tc *tokenCashierBase) PullTransfers(count uint16) error {
 		// this cycle, but this is not a failure: return nil so the caller still runs
 		// SubmitTransfers/CheckTransfers for already-confirmed transfers instead of
 		// skipping them (service.process skips those whenever PullTransfers errors).
+		// This was a healthy poll, so refresh lastPullTimestamp — otherwise a long
+		// stall would let it go stale and a later transient RPC error would fall
+		// through the grace window above and halt submissions mid-stall.
+		tc.lastPullTimestamp = time.Now()
 		return nil
 	}
 	var transfers []AbstractTransfer

--- a/witness-service/witness/tokencashierbase.go
+++ b/witness-service/witness/tokencashierbase.go
@@ -207,12 +207,15 @@ func (tc *tokenCashierBase) PullTransfers(count uint16) error {
 		return nil
 	}
 	if confirmHeight < startHeight {
-		// The confirmed tip has regressed below the last synced height: a load-balanced
-		// RPC returned an older tip, the finalized height moved backwards, or the DB was
-		// synced past the current confirmed tip (e.g. switching to finalized mode after
-		// syncing further under latest-minus-N). Do NOT treat this as a benign no-op —
-		// return an error so service.process skips submissions this cycle rather than
-		// signing already-ready rows that now sit above a confirmed tip that regressed.
+		// The confirmed tip has regressed below the last synced height by more
+		// than routine RPC jitter (finalized mode clamps that to a monotonic
+		// high-water mark upstream). The remaining causes are a genuine, large
+		// regression: the DB was synced past the current confirmed tip (e.g.
+		// switching to finalized mode after syncing further under latest-minus-N),
+		// or a serious RPC fault. Do NOT treat this as a benign no-op — return an
+		// error so service.process skips submissions this cycle rather than
+		// signing already-ready rows that now sit above a confirmed tip that
+		// regressed.
 		return errors.Errorf("confirm height %d regressed below sync height %d", confirmHeight, startHeight-1)
 	}
 	var transfers []AbstractTransfer

--- a/witness-service/witness/tokencashierbase.go
+++ b/witness-service/witness/tokencashierbase.go
@@ -195,17 +195,25 @@ func (tc *tokenCashierBase) PullTransfers(count uint16) error {
 		}
 		return errors.Wrapf(err, "failed to get end height and tip height with start height %d, count %d", startHeight, count)
 	}
-	if confirmHeight < startHeight {
-		// No new confirmed blocks since the last sync (e.g. the chain's finalized
-		// height has not advanced / finality is stalled). There is nothing to pull
-		// this cycle, but this is not a failure: return nil so the caller still runs
+	if confirmHeight+1 == startHeight {
+		// Exactly caught up: the confirmed tip equals the last synced height, so there
+		// are no new confirmed blocks this cycle (e.g. the chain's finalized height has
+		// not advanced / finality is stalled). This is not a failure: refresh
+		// lastPullTimestamp (a healthy poll, so a later transient RPC error still gets
+		// the grace window above) and return nil so the caller still runs
 		// SubmitTransfers/CheckTransfers for already-confirmed transfers instead of
 		// skipping them (service.process skips those whenever PullTransfers errors).
-		// This was a healthy poll, so refresh lastPullTimestamp — otherwise a long
-		// stall would let it go stale and a later transient RPC error would fall
-		// through the grace window above and halt submissions mid-stall.
 		tc.lastPullTimestamp = time.Now()
 		return nil
+	}
+	if confirmHeight < startHeight {
+		// The confirmed tip has regressed below the last synced height: a load-balanced
+		// RPC returned an older tip, the finalized height moved backwards, or the DB was
+		// synced past the current confirmed tip (e.g. switching to finalized mode after
+		// syncing further under latest-minus-N). Do NOT treat this as a benign no-op —
+		// return an error so service.process skips submissions this cycle rather than
+		// signing already-ready rows that now sit above a confirmed tip that regressed.
+		return errors.Errorf("confirm height %d regressed below sync height %d", confirmHeight, startHeight-1)
 	}
 	var transfers []AbstractTransfer
 	tc.lastPullTimestamp = time.Now()

--- a/witness-service/witness/tokencashierbase.go
+++ b/witness-service/witness/tokencashierbase.go
@@ -196,7 +196,12 @@ func (tc *tokenCashierBase) PullTransfers(count uint16) error {
 		return errors.Wrapf(err, "failed to get end height and tip height with start height %d, count %d", startHeight, count)
 	}
 	if confirmHeight < startHeight {
-		return errors.Errorf("failed to get end height with start height %d, count %d, confirm height %d", startHeight, count, confirmHeight)
+		// No new confirmed blocks since the last sync (e.g. the chain's finalized
+		// height has not advanced / finality is stalled). There is nothing to pull
+		// this cycle, but this is not a failure: return nil so the caller still runs
+		// SubmitTransfers/CheckTransfers for already-confirmed transfers instead of
+		// skipping them (service.process skips those whenever PullTransfers errors).
+		return nil
 	}
 	var transfers []AbstractTransfer
 	tc.lastPullTimestamp = time.Now()

--- a/witness-service/witness/tokencashieronethereum.go
+++ b/witness-service/witness/tokencashieronethereum.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"log"
 	"math/big"
+	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -228,11 +230,17 @@ func (iter *iterator) Transfers(start, end uint64) ([]AbstractTransfer, error) {
 	return transfers, nil
 }
 
+// finalizedRPCTimeout bounds a single finalized-block query so a hung RPC
+// endpoint cannot block the witness service loop indefinitely.
+const finalizedRPCTimeout = 10 * time.Second
+
 // fetchFinalizedHeight returns the height of the chain's finalized block via a
 // raw eth_getBlockByNumber("finalized") JSON-RPC call. It decodes only the block
 // number, so it does not depend on go-ethereum's types.Header struct (whose
 // fields drift across chains and versions).
 func fetchFinalizedHeight(ctx context.Context, rawClient *rpc.Client) (uint64, error) {
+	ctx, cancel := context.WithTimeout(ctx, finalizedRPCTimeout)
+	defer cancel()
 	var head struct {
 		Number *hexutil.Big `json:"number"`
 	}
@@ -243,6 +251,15 @@ func fetchFinalizedHeight(ctx context.Context, rawClient *rpc.Client) (uint64, e
 		return 0, errors.New("finalized block not available")
 	}
 	return head.Number.ToInt().Uint64(), nil
+}
+
+// ProbeFinalizedBlock verifies the RPC endpoint serves the "finalized" block
+// tag. A witness started with useFinalizedBlock calls this once at boot so it
+// fails fast on an endpoint that does not support the tag, instead of silently
+// stalling (every pull cycle would error and, after the grace window, stop
+// submitting) once it is running.
+func ProbeFinalizedBlock(ctx context.Context, rawClient *rpc.Client) (uint64, error) {
+	return fetchFinalizedHeight(ctx, rawClient)
 }
 
 // NewTokenCashierOnEthereum creates a new TokenCashier on ethereum
@@ -278,6 +295,13 @@ func NewTokenCashierOnEthereum(
 		}
 		pa = util.ETHAddressToAddress(previousCashierAddr)
 	}
+	// finalizedHighWater is the highest finalized height observed for this
+	// cashier. The finalized tag is monotonic by BFT finality, so a
+	// load-balanced RPC backend momentarily returning an older finalized height
+	// must not drag the confirmed tip backwards; keeping the high-water mark
+	// absorbs that jitter at the source (otherwise the regression guard in
+	// PullTransfers would fail the cycle and stall submissions).
+	var finalizedHighWater atomic.Uint64
 	return newTokenCashierBase(
 		id,
 		util.ETHAddressToAddress(cashierContractAddr),
@@ -312,6 +336,15 @@ func NewTokenCashierOnEthereum(
 				finalizedHeight, err := fetchFinalizedHeight(ctx, rawClient)
 				if err != nil {
 					return 0, 0, err
+				}
+				// Clamp to the highest finalized height seen so a stale RPC
+				// backend cannot move the confirmed tip backwards. A genuine
+				// finality reversion deeper than confirmBlockNumber is the
+				// catastrophic case the extra margin below is designed for.
+				if hw := finalizedHighWater.Load(); hw > finalizedHeight {
+					finalizedHeight = hw
+				} else {
+					finalizedHighWater.Store(finalizedHeight)
 				}
 				var confirmHeight uint64
 				if finalizedHeight > confirmBlockNumber {

--- a/witness-service/witness/tokencashieronethereum.go
+++ b/witness-service/witness/tokencashieronethereum.go
@@ -292,18 +292,30 @@ func NewTokenCashierOnEthereum(
 				count = 1
 			}
 			if useFinalizedBlock {
-				// Use the chain's finalized block as the confirmed tip. A finalized
-				// block cannot be reorged, so this is fail-safe: during a finality
-				// stall the finalized height simply freezes and the witness waits
-				// (the base treats "no newly finalized blocks" as a no-op cycle, so
-				// already-ready transfers keep being submitted throughout the stall).
-				// endHeight is capped at the finalized height as well, so PullTransfers
-				// never scans or stores still-reorgable receipts above it (an
-				// unfinalized row that later reorgs would otherwise be flipped to
-				// "ready" by UpsertTransfer while keeping its stale recipient/amount).
-				confirmHeight, err := fetchFinalizedHeight(ctx, rawClient)
+				// Use the chain's finalized block, minus an optional extra safety
+				// margin (confirmBlockNumber), as the confirmed tip. Finalized removes
+				// routine reorgs and most reorg-based attacks (BFT finality). The extra
+				// margin is defense in depth for a bridge, where the catastrophic case
+				// is not an everyday reorg but a deliberate attack that breaks the
+				// chain's finality gadget itself — which the >=3/4 witness multisig
+				// cannot catch because it is correlated across all witnesses watching
+				// the same chain. Waiting confirmBlockNumber blocks past finalized buys
+				// time for such a failure to be detected before crediting, and yields
+				// the strictly stronger "finalized AND N-deep" guarantee. Set
+				// confirmBlockNumber to 0 to trust finalized alone. endHeight is capped
+				// at confirmHeight so PullTransfers never stores still-reorgable
+				// receipts above it (an unfinalized/too-shallow row that later reorgs
+				// would otherwise be flipped to "ready" by UpsertTransfer while keeping
+				// its stale recipient/amount). During a finality stall confirmHeight
+				// freezes and the base treats it as a no-op cycle, so already-ready
+				// transfers keep being submitted throughout the stall.
+				finalizedHeight, err := fetchFinalizedHeight(ctx, rawClient)
 				if err != nil {
 					return 0, 0, err
+				}
+				var confirmHeight uint64
+				if finalizedHeight > confirmBlockNumber {
+					confirmHeight = finalizedHeight - confirmBlockNumber
 				}
 				endHeight := startHeight + uint64(count) - 1
 				if confirmHeight < endHeight {

--- a/witness-service/witness/tokencashieronethereum.go
+++ b/witness-service/witness/tokencashieronethereum.go
@@ -303,6 +303,17 @@ func NewTokenCashierOnEthereum(
 				if err != nil {
 					return 0, 0, err
 				}
+				if confirmHeight < startHeight {
+					// No newly finalized blocks since the last sync (caught up, or
+					// finality has stalled). Signal this as a transient error so the
+					// base falls through its existing grace window and PullTransfers
+					// returns nil, rather than tripping the hard "confirmHeight <
+					// startHeight" error below. That keeps already-ready transfers
+					// flowing through SubmitTransfers/CheckTransfers during the short
+					// stalls this mode is meant to tolerate (service.process skips
+					// those steps whenever PullTransfers returns an error).
+					return 0, 0, errors.Errorf("no newly finalized blocks: finalized height %d is below next start height %d", confirmHeight, startHeight)
+				}
 				endHeight := startHeight + uint64(count) - 1
 				if confirmHeight < endHeight {
 					endHeight = confirmHeight

--- a/witness-service/witness/tokencashieronethereum.go
+++ b/witness-service/witness/tokencashieronethereum.go
@@ -288,30 +288,37 @@ func NewTokenCashierOnEthereum(
 		startBlockHeight,
 		func(startHeight uint64, count uint16) (uint64, uint64, error) {
 			ctx := context.Background()
+			if count == 0 {
+				count = 1
+			}
+			if useFinalizedBlock {
+				// Use the chain's finalized block as the confirmed tip. A finalized
+				// block cannot be reorged, so this is fail-safe: during a finality
+				// stall the finalized height simply freezes and the witness waits.
+				// endHeight is capped at the finalized height as well, so PullTransfers
+				// never scans or stores still-reorgable receipts above it (an
+				// unfinalized row that later reorgs would otherwise be flipped to
+				// "ready" by UpsertTransfer while keeping its stale recipient/amount).
+				confirmHeight, err := fetchFinalizedHeight(ctx, rawClient)
+				if err != nil {
+					return 0, 0, err
+				}
+				endHeight := startHeight + uint64(count) - 1
+				if confirmHeight < endHeight {
+					endHeight = confirmHeight
+				}
+				return confirmHeight, endHeight, nil
+			}
+			// Fallback: probabilistic latest-minus-N confirmation.
 			tipHeader, err := ethereumClient.HeaderByNumber(ctx, nil)
 			if err != nil {
 				return 0, 0, errors.Wrap(err, "failed to query tip block header")
 			}
 			tipHeight := tipHeader.Number.Uint64()
-			if count == 0 {
-				count = 1
+			if tipHeight <= confirmBlockNumber {
+				return 0, 0, errors.Errorf("tip height %d is smaller than confirm block number %d", tipHeight, confirmBlockNumber)
 			}
-			// confirmHeight is the highest block considered safe to sign. When
-			// useFinalizedBlock is set, it is the chain's finalized block (fail-safe:
-			// it freezes during a finality stall instead of advancing). Otherwise it
-			// falls back to the probabilistic latest-minus-N rule.
-			var confirmHeight uint64
-			if useFinalizedBlock {
-				confirmHeight, err = fetchFinalizedHeight(ctx, rawClient)
-				if err != nil {
-					return 0, 0, err
-				}
-			} else {
-				if tipHeight <= confirmBlockNumber {
-					return 0, 0, errors.Errorf("tip height %d is smaller than confirm block number %d", tipHeight, confirmBlockNumber)
-				}
-				confirmHeight = tipHeight - confirmBlockNumber
-			}
+			confirmHeight := tipHeight - confirmBlockNumber
 			endHeight := startHeight + uint64(count) - 1
 			if tipHeight < endHeight {
 				endHeight = tipHeight

--- a/witness-service/witness/tokencashieronethereum.go
+++ b/witness-service/witness/tokencashieronethereum.go
@@ -294,7 +294,9 @@ func NewTokenCashierOnEthereum(
 			if useFinalizedBlock {
 				// Use the chain's finalized block as the confirmed tip. A finalized
 				// block cannot be reorged, so this is fail-safe: during a finality
-				// stall the finalized height simply freezes and the witness waits.
+				// stall the finalized height simply freezes and the witness waits
+				// (the base treats "no newly finalized blocks" as a no-op cycle, so
+				// already-ready transfers keep being submitted throughout the stall).
 				// endHeight is capped at the finalized height as well, so PullTransfers
 				// never scans or stores still-reorgable receipts above it (an
 				// unfinalized row that later reorgs would otherwise be flipped to
@@ -302,17 +304,6 @@ func NewTokenCashierOnEthereum(
 				confirmHeight, err := fetchFinalizedHeight(ctx, rawClient)
 				if err != nil {
 					return 0, 0, err
-				}
-				if confirmHeight < startHeight {
-					// No newly finalized blocks since the last sync (caught up, or
-					// finality has stalled). Signal this as a transient error so the
-					// base falls through its existing grace window and PullTransfers
-					// returns nil, rather than tripping the hard "confirmHeight <
-					// startHeight" error below. That keeps already-ready transfers
-					// flowing through SubmitTransfers/CheckTransfers during the short
-					// stalls this mode is meant to tolerate (service.process skips
-					// those steps whenever PullTransfers returns an error).
-					return 0, 0, errors.Errorf("no newly finalized blocks: finalized height %d is below next start height %d", confirmHeight, startHeight)
 				}
 				endHeight := startHeight + uint64(count) - 1
 				if confirmHeight < endHeight {

--- a/witness-service/witness/tokencashieronethereum.go
+++ b/witness-service/witness/tokencashieronethereum.go
@@ -13,8 +13,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/pkg/errors"
 
 	"github.com/iotexproject/ioTube/witness-service/contract"
@@ -226,19 +228,38 @@ func (iter *iterator) Transfers(start, end uint64) ([]AbstractTransfer, error) {
 	return transfers, nil
 }
 
+// fetchFinalizedHeight returns the height of the chain's finalized block via a
+// raw eth_getBlockByNumber("finalized") JSON-RPC call. It decodes only the block
+// number, so it does not depend on go-ethereum's types.Header struct (whose
+// fields drift across chains and versions).
+func fetchFinalizedHeight(ctx context.Context, rawClient *rpc.Client) (uint64, error) {
+	var head struct {
+		Number *hexutil.Big `json:"number"`
+	}
+	if err := rawClient.CallContext(ctx, &head, "eth_getBlockByNumber", "finalized", false); err != nil {
+		return 0, errors.Wrap(err, "failed to query finalized block header")
+	}
+	if head.Number == nil {
+		return 0, errors.New("finalized block not available")
+	}
+	return head.Number.ToInt().Uint64(), nil
+}
+
 // NewTokenCashierOnEthereum creates a new TokenCashier on ethereum
 func NewTokenCashierOnEthereum(
 	id string,
 	version Version,
 	relayerURL string,
 	ethereumClient *ethclient.Client,
+	rawClient *rpc.Client,
 	cashierContractAddr common.Address,
 	previousCashierAddr common.Address,
 	tokenSafeContractAddr common.Address,
 	validatorContractAddr []byte,
 	recorder *Recorder,
 	startBlockHeight uint64,
-	confirmBlockNumber uint8,
+	confirmBlockNumber uint64,
+	useFinalizedBlock bool,
 	signHandler SignHandler,
 	reverseRecorder *Recorder,
 	reverseCashierContractAddr common.Address,
@@ -266,7 +287,8 @@ func NewTokenCashierOnEthereum(
 		validatorContractAddr,
 		startBlockHeight,
 		func(startHeight uint64, count uint16) (uint64, uint64, error) {
-			tipHeader, err := ethereumClient.HeaderByNumber(context.Background(), nil)
+			ctx := context.Background()
+			tipHeader, err := ethereumClient.HeaderByNumber(ctx, nil)
 			if err != nil {
 				return 0, 0, errors.Wrap(err, "failed to query tip block header")
 			}
@@ -274,14 +296,27 @@ func NewTokenCashierOnEthereum(
 			if count == 0 {
 				count = 1
 			}
-			if tipHeight <= uint64(confirmBlockNumber) {
-				return 0, 0, errors.Errorf("tip height %d is smaller than confirm block number %d", tipHeight, confirmBlockNumber)
+			// confirmHeight is the highest block considered safe to sign. When
+			// useFinalizedBlock is set, it is the chain's finalized block (fail-safe:
+			// it freezes during a finality stall instead of advancing). Otherwise it
+			// falls back to the probabilistic latest-minus-N rule.
+			var confirmHeight uint64
+			if useFinalizedBlock {
+				confirmHeight, err = fetchFinalizedHeight(ctx, rawClient)
+				if err != nil {
+					return 0, 0, err
+				}
+			} else {
+				if tipHeight <= confirmBlockNumber {
+					return 0, 0, errors.Errorf("tip height %d is smaller than confirm block number %d", tipHeight, confirmBlockNumber)
+				}
+				confirmHeight = tipHeight - confirmBlockNumber
 			}
 			endHeight := startHeight + uint64(count) - 1
 			if tipHeight < endHeight {
 				endHeight = tipHeight
 			}
-			return tipHeight - uint64(confirmBlockNumber), endHeight, nil
+			return confirmHeight, endHeight, nil
 		},
 		iter.Transfers,
 		signHandler,


### PR DESCRIPTION
## What

Adds an opt-in reorg-protection mode where the witness treats a source chain's **`finalized` block** as the confirmed tip, instead of the current probabilistic `latest - confirmBlockNumber` rule. Also fixes a latent overflow in `confirmBlockNumber`.

## Why

The witness only signs a source-chain transfer once it considers the block "confirmed". Today that is a fixed depth below `latest`. Two problems:

1. **A fixed confirmation count does not survive a finality stall.** If a chain's finality halts while blocks keep being produced, `latest - N` keeps advancing, so the witness can confirm a range that is not yet final and could still be reorged. Reading the chain's `finalized` tag is fail-safe: during a stall the finalized pointer simply freezes and the witness waits.
2. **`confirmBlockNumber` was `uint8` (max 255).** Config values above 255 silently wrapped (e.g. 300 → 44), quietly weakening protection. Widened to `uint64`.

## How

- New top-level config flag `useFinalizedBlock` (default `false`, fully backward compatible).
- When set, the confirmed height is the chain's finalized block, fetched via a **raw `eth_getBlockByNumber("finalized")` JSON-RPC call**. The pinned go-ethereum's `ethclient` cannot request the `finalized`/`safe` tags (its `toBlockNumArg` predates them), so the call is made on the underlying `*rpc.Client`. The response is decoded reading **only the block number**, so it is independent of the go-ethereum version and of the chain's header struct/fields.
- When unset, behavior is identical to before (`latest - confirmBlockNumber`, now with the overflow fixed).

## Validation

Sampled `latest` and `finalized` on Polygon and BSC mainnet RPCs every 30s for ~22 hours (2458 samples/chain):

| Chain | finalized reversions | monotonic | lag behind `latest` (median / max) |
|---|---|---|---|
| Polygon | 0 | yes | 3 / 5 blocks (~4s / 8s) |
| BSC | 0 | yes | 1 / 4 blocks (~1s / 2s) |

Finalized advanced strictly monotonically with **zero reversions** — and over the same window `latest` itself never moved backward either. This confirms the tag is genuine fast finality (not an alias of `latest`) and safe to gate signing on. On both chains the finalized lag is a few seconds, so enabling this is also *faster* than a large fixed confirmation count while giving cryptographic (non-reorgable) finality.

## Choosing `confirmBlockNumber` (defense in depth)

With `useFinalizedBlock: true`, `confirmBlockNumber` is applied as an **additional buffer below the finalized tip** (`confirmHeight = finalized - confirmBlockNumber`), not as the primary safety margin — the finalized tag is already non-reorgable under normal operation. The buffer exists to survive a correlated **finality-gadget failure**: the one failure mode a witness multisig cannot catch, because every honest witness reads the same faulty finalized pointer. Depth/time is the only defense there.

Sizing is asymmetric, per each chain's documented reorg history:

| Chain | Historical max reorg | Current finality | Suggested buffer | Rationale |
|---|---|---|---|---|
| Polygon | **128 blocks** (2020, sprintLength 64); 32 (Delhi, 2023) | Heimdall v2 milestones, reorg ≤ 2 blocks (~5s) | **500** (~12.5 min) | Exceeds the **256**-block confirmation Polygon officially advised during the 2025-07-10 Heimdall v2 upgrade window (finality lagged ~3h); also exceeds the historical 128-block max |
| BSC | no deep-reorg history; ~15-block probabilistic pre-finality | BEP-126 fast finality, ~2–2.5 blocks; finalized never reverted | **50** (~22s) | > 3× the pre-finality 15-block threshold |

A finalized **stall** is already fail-safe on its own (the witness stops advancing and simply under-signs/delays); the buffer is the extra margin against a finalized value that advances and is later reverted — historically unobserved on both chains, but cheap insurance for a bridge, where a single incorrect confirmation is catastrophic rather than a routine reorg.

## Rollout

- Opt-in and off by default — no behavior change until `useFinalizedBlock: true` is set for a chain, which should be done only after the new binary is deployed and against an RPC that serves the `finalized` tag.
- `go build ./...` and `go vet ./witness/... ./cmd/witness/...` pass.
