### PR TITLE
relayer: order the user-facing List by creationTime, not blockHeight

### DIFF
--- a/witness-service/relayer/recorder.go
+++ b/witness-service/relayer/recorder.go
@@ -704,14 +704,27 @@ func (recorder *Recorder) TransfersWithFBO(
 ) ([]*Transfer, error) {
 	recorder.mutex.RLock()
 	defer recorder.mutex.RUnlock()
-	// Order the user-facing List by blockHeight (the source-chain block, i.e. the
-	// real transfer time) rather than creationTime (when the row was inserted on
-	// this relayer). Re-submitting an old transfer stamps a fresh creationTime and
-	// would otherwise jump it to the top of the list; each payload relayer serves a
-	// single source chain, so blockHeight is monotonic in real time here.
+	// Order the user-facing List by creationTime.
+	//
+	// A previous change ordered this by blockHeight on the assumption that "each
+	// payload relayer serves a single source chain, so blockHeight is monotonic in
+	// real time". That does NOT hold for the into-IoTeX relayer, whose table
+	// aggregates transfers from multiple source chains (BSC, Polygon, Solana, ...).
+	// Block/slot heights are only comparable within a single chain, so a global
+	// ORDER BY blockHeight interleaves chains by their arbitrary numbering scales:
+	// Solana slots (~4e8) always sort above BSC blocks (~1.1e8) and Polygon blocks
+	// (~9e7), so months-old Solana transfers dominate the top of the list and bury
+	// genuinely recent BSC/Polygon transfers, making "recent transactions" look
+	// empty. creationTime is comparable across chains and is preserved across DB
+	// restores, so it restores a sane chronological order for the mixed-source list.
+	//
+	// Known tradeoff: re-submitting an old transfer stamps a fresh creationTime and
+	// briefly jumps it to the top. Ordering by a real per-row source-block timestamp
+	// (persisted at ingest from the witness-reported block time) is the proper
+	// follow-up that fixes both the cross-chain and the re-submit cases.
 	return recorder.transfers(
 		fmt.Sprintf("SELECT `cashier`, IFNULL(`fbo_token`, `token`), `tidx`, `sender`, `txSender`, IFNULL(`fbo_recipient`, `recipient`), `amount`, `payload`, `fee`, `id`, `txHash`, `txTimestamp`, `nonce`, `gas`, `gasPrice`, `status`, `updateTime`, `relayer` FROM %s", recorder.transferTableName),
-		"blockHeight",
+		"creationTime",
 		offset,
 		limit,
 		desc,


### PR DESCRIPTION
## Problem

The into-IoTeX "recent transactions" list showed no recent transfers — old (months-old) transfers appeared at the top and genuinely recent ones were buried.

## Root cause

#320 switched the user-facing List (`TransfersWithFBO`) to `ORDER BY blockHeight`, on the assumption that *"each payload relayer serves a single source chain, so blockHeight is monotonic in real time."*

That assumption holds for the **out-going** relayers (each serves iotex→X, single source = IoTeX) but **not** for the **into-IoTeX** relayer: its table aggregates transfers from **multiple source chains** (BSC, Polygon, Solana, …), whose block/slot numbers live on wildly different scales:

| source | cashier | blockHeight range |
|---|---|---|
| Solana | `A9SGRcytnf…` | 2.8e8 – **4.0e8** |
| BSC | `0x78de1E0b…` | 4.4e7 – **1.1e8** |
| Polygon | `0x990B503f…` | 6.4e7 – **9.0e7** |

A global `ORDER BY blockHeight DESC` interleaves chains by their numbering scale rather than by time — Solana slots (~4e8) always sort above BSC (~1.1e8) and Polygon (~9e7) blocks, so **Feb-2026 Solana transfers dominate the top** and bury genuinely recent BSC/Polygon transfers → the list looks empty.

## Fix

Revert the List ordering to `creationTime`, which is comparable across chains and is preserved across DB restores. Internal processing queues (bonus/confirm/submit) were already on `creationTime` and are unaffected — only the user-facing List path changes.

## Known tradeoff / follow-up

Re-submitting an old transfer stamps a fresh `creationTime` and briefly jumps it to the top (the case #320 set out to fix). The proper long-term fix is to persist a real **per-row source-block timestamp** at ingest (the witness already reports the source block time over gRPC; it is currently dropped) and order by that — cross-chain comparable **and** re-submit-proof. That is a larger change (schema + ingest + backfill) and is left as follow-up.

## Test

- `go build ./relayer/...` passes; `gofmt` clean.
- Verified against the live relayer DB: ordering `iotex_transfers` by `blockHeight DESC` surfaces Feb-2026 Solana rows first; ordering by `creationTime DESC` surfaces the actually-recent Polygon/BSC transfers.