### PR TITLE
relayer: harden witness ingress and settlement quorum

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,6 +45,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/witness-service/README.md
+++ b/witness-service/README.md
@@ -73,7 +73,7 @@ git pull --recurse-submodules && ./upgrade.sh
 `upgrade.sh` pulls/recreates only the witness services (never the database), does a
 non-destructive image prune, and migrates a legacy compose file if it still pins the
 old local `witness:latest` tag. To pin or roll back a version, set
-`WITNESS_TAG=<tag>` in `<data-dir>/etc/.env` and re-run `./upgrade.sh`.
+`WITNESS_TAG=sha-<commit>` in `<data-dir>/etc/.env` and re-run `./upgrade.sh`.
 
 ## Build the image
 
@@ -84,3 +84,20 @@ docker build -f witness-service/Dockerfile.witness -t iotube-witness .
 Release CI publishes `ghcr.io/iotubeproject/iotube-witness:latest`
 (`.github/workflows/docker-publish.yml`), which is what the compose file pulls by
 default.
+
+## Relayer API boundaries
+
+The relayer HTTP gateway exposes only the read methods `check`, `list`,
+`listnewtx`, and `lookup`. Witness submissions and heartbeats use gRPC directly.
+Administrative methods (`Reset`, `Retry`, and `SubmitNewTX`) are local-only and
+disabled unless `RELAYER_ADMIN_TOKEN` is set. An administrative gRPC caller must
+run inside the relayer container, connect through loopback, and send
+`authorization: Bearer <token>` metadata.
+
+Witness submissions must carry a valid 65-byte signature from a currently active
+on-chain witness. If the relayer cannot refresh the witness set, it rejects new
+submissions until the chain RPC recovers. Transfer proposals are stored by their
+signed transfer ID, and only proposals with more than two-thirds of the current
+active witnesses enter the settlement queue. On first startup after upgrading,
+legacy MySQL transfer tables are migrated from the `(cashier, token, tidx)` primary
+key to the transfer ID; back up the relayer database before deploying the upgrade.

--- a/witness-service/README.md
+++ b/witness-service/README.md
@@ -94,10 +94,12 @@ disabled unless `RELAYER_ADMIN_TOKEN` is set. An administrative gRPC caller must
 run inside the relayer container, connect through loopback, and send
 `authorization: Bearer <token>` metadata.
 
-Witness submissions must carry a valid 65-byte signature from a currently active
-on-chain witness. If the relayer cannot refresh the witness set, it rejects new
-submissions until the chain RPC recovers. Transfer proposals are stored by their
-signed transfer ID, and only proposals with more than two-thirds of the current
-active witnesses enter the settlement queue. On first startup after upgrading,
-legacy MySQL transfer tables are migrated from the `(cashier, token, tidx)` primary
-key to the transfer ID; back up the relayer database before deploying the upgrade.
+Persisted witness submissions must carry a valid 65-byte signature from a currently
+active on-chain witness. For rolling-upgrade compatibility, legacy unsigned
+pre-announcements receive a no-op acknowledgement but are never stored. If the
+relayer cannot refresh the witness set, it rejects signed submissions until the
+chain RPC recovers. Transfer proposals are stored by their signed transfer ID, and
+only proposals with more than two-thirds of the current active witnesses enter the
+settlement queue. On first startup after upgrading, legacy MySQL transfer tables are
+migrated from the `(cashier, token, tidx)` primary key to the transfer ID; back up
+the relayer database before deploying the upgrade.

--- a/witness-service/cmd/relayer/main.go
+++ b/witness-service/cmd/relayer/main.go
@@ -308,7 +308,7 @@ func main() {
 		service = ethService
 	}
 
-	relayer.StartServer(service, cfg.GrpcPort, cfg.GrpcProxyPort)
+	relayer.StartServer(service, cfg.GrpcPort, cfg.GrpcProxyPort, os.Getenv("RELAYER_ADMIN_TOKEN"))
 
 	select {}
 }

--- a/witness-service/cmd/witness/config_test.go
+++ b/witness-service/cmd/witness/config_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/config"
+)
+
+func TestBSCConfigEnablesFinalizedBlocks(t *testing.T) {
+	configPath := filepath.Join("..", "..", "configs", "witness-config-bsc-payload.yaml")
+	yaml, err := config.NewYAML(
+		config.Static(defaultConfig),
+		config.File(configPath),
+	)
+	require.NoError(t, err)
+
+	var cfg Configuration
+	require.NoError(t, yaml.Get(config.Root).Populate(&cfg))
+	require.Equal(t, "bsc", cfg.Chain)
+	require.True(t, cfg.UseFinalizedBlock)
+	require.Equal(t, 20, cfg.ConfirmBlockNumber)
+}

--- a/witness-service/cmd/witness/config_test.go
+++ b/witness-service/cmd/witness/config_test.go
@@ -20,5 +20,5 @@ func TestBSCConfigEnablesFinalizedBlocks(t *testing.T) {
 	require.NoError(t, yaml.Get(config.Root).Populate(&cfg))
 	require.Equal(t, "bsc", cfg.Chain)
 	require.True(t, cfg.UseFinalizedBlock)
-	require.Equal(t, 20, cfg.ConfirmBlockNumber)
+	require.Equal(t, 50, cfg.ConfirmBlockNumber)
 }

--- a/witness-service/cmd/witness/main.go
+++ b/witness-service/cmd/witness/main.go
@@ -312,7 +312,7 @@ func main() {
 			probeCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			if _, err := witness.ProbeFinalizedBlock(probeCtx, rpcClient); err != nil {
 				cancel()
-				log.Fatalf("useFinalizedBlock is enabled but RPC %s does not serve the finalized block tag: %v\n", cfg.ClientURL, err)
+				log.Fatalf("useFinalizedBlock is enabled but the configured RPC does not serve the finalized block tag: %v\n", err)
 			}
 			cancel()
 		}

--- a/witness-service/docker-compose-relayer.yml
+++ b/witness-service/docker-compose-relayer.yml
@@ -3,6 +3,7 @@ version: '2'
 # Required .env values (copy .env.template -> .env next to this file, then fill in):
 #   IOTEX_RELAYER    - absolute path to the relayer deploy dir (holds etc/ and data/)
 #   DB_ROOT_PASSWORD - MySQL root password for the local relayer-db
+# Optional: RELAYER_ADMIN_TOKEN enables local-only administrative gRPC methods.
 # If either is unset, docker compose fails fast with a clear message (the ${VAR:?...}
 # guards below) instead of silently mounting empty directories over the config files.
 
@@ -32,6 +33,7 @@ services:
     command: relayer -config=/etc/iotube-relayer/relayer-config-iotex-payload.yaml
     environment:
       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+      RELAYER_ADMIN_TOKEN: ${RELAYER_ADMIN_TOKEN:-}
       DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
 #   ethereum-payload-relayer:
@@ -48,6 +50,7 @@ services:
 #     command: relayer -config=/etc/iotube-relayer/relayer-config-ethereum-payload.yaml
 #     environment:
 #       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+#       RELAYER_ADMIN_TOKEN: ${RELAYER_ADMIN_TOKEN:-}
 
   bsc-payload-relayer:
     container_name: bsc-payload-relayer
@@ -63,6 +66,7 @@ services:
     command: relayer -config=/etc/iotube-relayer/relayer-config-bsc-payload.yaml
     environment:
       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+      RELAYER_ADMIN_TOKEN: ${RELAYER_ADMIN_TOKEN:-}
       DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 
 #   matic-payload-relayer:
@@ -79,6 +83,7 @@ services:
 #     command: relayer -config=/etc/iotube-relayer/relayer-config-matic-payload.yaml
 #     environment:
 #       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+#       RELAYER_ADMIN_TOKEN: ${RELAYER_ADMIN_TOKEN:-}
 
 #   iotex-solana-relayer:
 #     container_name: iotex-solana-relayer
@@ -94,6 +99,7 @@ services:
 #     command: relayer -config=/etc/iotube-relayer/relayer-config-iotex-solana.yaml
 #     environment:
 #       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+#       RELAYER_ADMIN_TOKEN: ${RELAYER_ADMIN_TOKEN:-}
 
 #   solana-relayer:
 #     container_name: solana-relayer
@@ -109,6 +115,7 @@ services:
 #     command: relayer -config=/etc/iotube-relayer/relayer-config-solana.yaml
 #     environment:
 #       RELAYER_PRIVATE_KEY: ${RELAYER_PRIVATE_KEY}
+#       RELAYER_ADMIN_TOKEN: ${RELAYER_ADMIN_TOKEN:-}
 
 #   cron:
 #     image: schnitzler/mysqldump

--- a/witness-service/relayer/recorder.go
+++ b/witness-service/relayer/recorder.go
@@ -141,8 +141,8 @@ func (recorder *Recorder) initStore(
 			"`payload` varchar(24576),"+ // MaxCodeSize
 			"`fbo_recipient` varchar(256),"+
 			"`fbo_token` varchar(42),"+
-			"PRIMARY KEY (`cashier`,`token`,`tidx`),"+
-			"UNIQUE KEY `id_UNIQUE` (`id`),"+
+			"PRIMARY KEY (`id`),"+
+			"KEY `cashier_token_tidx_index` (`cashier`,`token`,`tidx`),"+
 			"KEY `cashier_index` (`cashier`),"+
 			"KEY `token_index` (`token`),"+
 			"KEY `sender_index` (`sender`),"+
@@ -158,6 +158,9 @@ func (recorder *Recorder) initStore(
 		WaitingForWitnesses,
 	)); err != nil {
 		return errors.Wrap(err, "failed to create transfer table")
+	}
+	if err := migrateTransferPrimaryKey(store, transferTableName); err != nil {
+		return errors.Wrapf(err, "failed to migrate transfer table %s", transferTableName)
 	}
 	if witnessTableName != "" {
 		if _, err := store.DB().Exec(fmt.Sprintf(
@@ -220,6 +223,100 @@ func (recorder *Recorder) initStore(
 	)
 
 	return err
+}
+
+func mysqlIdentifier(identifier string) (string, error) {
+	if identifier == "" {
+		return "", errors.New("empty SQL identifier")
+	}
+	for _, r := range identifier {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_' {
+			return "", errors.Errorf("invalid SQL identifier %q", identifier)
+		}
+	}
+	return "`" + identifier + "`", nil
+}
+
+func mysqlTable(store *db.SQLStore, tableName string) (schema, table, quoted string, err error) {
+	parts := strings.Split(tableName, ".")
+	if len(parts) > 2 {
+		return "", "", "", errors.Errorf("invalid table name %q", tableName)
+	}
+	table = parts[len(parts)-1]
+	quotedTable, err := mysqlIdentifier(table)
+	if err != nil {
+		return "", "", "", err
+	}
+	if len(parts) == 2 {
+		schema = parts[0]
+		quotedSchema, err := mysqlIdentifier(schema)
+		if err != nil {
+			return "", "", "", err
+		}
+		return schema, table, quotedSchema + "." + quotedTable, nil
+	}
+	if err := store.DB().QueryRow("SELECT DATABASE()").Scan(&schema); err != nil {
+		return "", "", "", errors.Wrap(err, "failed to resolve current database")
+	}
+	return schema, table, quotedTable, nil
+}
+
+// migrateTransferPrimaryKey changes legacy first-write-wins tables from the
+// source tuple key to the signed transfer ID. Conflicting proposals can then
+// coexist until one independently reaches witness quorum.
+func migrateTransferPrimaryKey(store *db.SQLStore, tableName string) error {
+	if store.DriverName() != "mysql" {
+		return nil
+	}
+	schema, table, quotedTable, err := mysqlTable(store, tableName)
+	if err != nil {
+		return err
+	}
+	var primaryColumns sql.NullString
+	if err := store.DB().QueryRow(
+		"SELECT GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') "+
+			"FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA=? AND TABLE_NAME=? AND INDEX_NAME='PRIMARY'",
+		schema,
+		table,
+	).Scan(&primaryColumns); err != nil {
+		return errors.Wrap(err, "failed to inspect transfer primary key")
+	}
+	if primaryColumns.String == "id" {
+		return nil
+	}
+	if primaryColumns.String != "cashier,token,tidx" {
+		return errors.Errorf("unsupported primary key %q", primaryColumns.String)
+	}
+	var routeIndexColumns int
+	if err := store.DB().QueryRow(
+		"SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS "+
+			"WHERE TABLE_SCHEMA=? AND TABLE_NAME=? AND INDEX_NAME='cashier_token_tidx_index'",
+		schema,
+		table,
+	).Scan(&routeIndexColumns); err != nil {
+		return errors.Wrap(err, "failed to inspect transfer route index")
+	}
+	alter := fmt.Sprintf("ALTER TABLE %s DROP PRIMARY KEY, ADD PRIMARY KEY (`id`)", quotedTable)
+	if routeIndexColumns == 0 {
+		alter += ", ADD KEY `cashier_token_tidx_index` (`cashier`,`token`,`tidx`)"
+	}
+	if _, err := store.DB().Exec(alter); err != nil {
+		// Multiple relayer processes can share a table and race this one-time DDL.
+		// If another process completed the migration while this ALTER waited, the
+		// desired schema is already present and startup remains idempotent.
+		var migratedColumns sql.NullString
+		inspectErr := store.DB().QueryRow(
+			"SELECT GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') "+
+				"FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA=? AND TABLE_NAME=? AND INDEX_NAME='PRIMARY'",
+			schema,
+			table,
+		).Scan(&migratedColumns)
+		if inspectErr == nil && migratedColumns.String == "id" {
+			return nil
+		}
+		return errors.Wrap(err, "failed to replace transfer primary key")
+	}
+	return nil
 }
 
 // Stop stops the recorder
@@ -337,7 +434,7 @@ func (recorder *Recorder) addTransferAndWitness(
 	fboToken, fboRecipient *common.Address,
 ) error {
 	if _, err := tx.Exec(
-		fmt.Sprintf("INSERT IGNORE INTO %s (cashier, token, tidx, sender, txSender, recipient, amount, payload, fee, id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", transferTableName),
+		fmt.Sprintf("INSERT INTO %s (cashier, token, tidx, sender, txSender, recipient, amount, payload, fee, id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE id=VALUES(id)", transferTableName),
 		transfer.cashier.String(),
 		transfer.token.String(),
 		transfer.index,
@@ -752,6 +849,53 @@ func (recorder *Recorder) Transfers(
 	)
 }
 
+// TransfersWithWitnessQuorum returns only waiting transfers signed by more than
+// two thirds of the current active witness set. Rows without quorum never enter
+// the settlement queue, so they cannot head-of-line block valid transfers.
+func (recorder *Recorder) TransfersWithWitnessQuorum(
+	limit uint8,
+	activeWitnesses []common.Address,
+	queryOpts ...TransferQueryOption,
+) ([]*Transfer, error) {
+	recorder.mutex.RLock()
+	defer recorder.mutex.RUnlock()
+	if recorder.witnessTableName == "" {
+		return nil, errors.New("witness table is not configured")
+	}
+	if len(activeWitnesses) == 0 {
+		return nil, errors.New("active witness set is empty")
+	}
+
+	query := fmt.Sprintf(
+		"SELECT t.`cashier`, t.`token`, t.`tidx`, t.`sender`, t.`txSender`, t.`recipient`, t.`amount`, t.`payload`, t.`fee`, t.`id`, t.`txHash`, t.`txTimestamp`, t.`nonce`, t.`gas`, t.`gasPrice`, t.`status`, t.`updateTime`, t.`relayer` FROM %s AS t",
+		recorder.transferTableName,
+	)
+	queryOpts = append(queryOpts, StatusQueryOption(WaitingForWitnesses), ExcludeAmountZeroOption())
+	conditions := make([]string, 0, len(queryOpts)+1)
+	params := []interface{}{}
+	for _, opt := range queryOpts {
+		condition, ps := opt()
+		if condition == "" {
+			continue
+		}
+		conditions = append(conditions, condition)
+		params = append(params, ps...)
+	}
+	witnessPlaceholders := strings.TrimSuffix(strings.Repeat("?,", len(activeWitnesses)), ",")
+	conditions = append(conditions, fmt.Sprintf(
+		"(SELECT COUNT(*) FROM %s AS w WHERE w.`transferId`=t.`id` AND w.`witness` IN (%s))*3 > ?",
+		recorder.witnessTableName,
+		witnessPlaceholders,
+	))
+	for _, witness := range activeWitnesses {
+		params = append(params, witness.Hex())
+	}
+	params = append(params, len(activeWitnesses)*2)
+	query += " WHERE " + strings.Join(conditions, " AND ") + " ORDER BY t.`creationTime` ASC LIMIT ?"
+	params = append(params, limit)
+	return recorder.queryTransfers(query, params...)
+}
+
 func (recorder *Recorder) transfers(
 	query string,
 	orderBy string,
@@ -781,7 +925,10 @@ func (recorder *Recorder) transfers(
 	}
 	query += " LIMIT ?, ?"
 	params = append(params, offset, limit)
+	return recorder.queryTransfers(query, params...)
+}
 
+func (recorder *Recorder) queryTransfers(query string, params ...interface{}) ([]*Transfer, error) {
 	rows, err := recorder.store.DB().Query(query, params...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query transfers table")

--- a/witness-service/relayer/recorder_integration_test.go
+++ b/witness-service/relayer/recorder_integration_test.go
@@ -1,0 +1,142 @@
+package relayer
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/ioTube/witness-service/db"
+	"github.com/iotexproject/ioTube/witness-service/util"
+)
+
+func mysqlIntegrationStore(t *testing.T) *db.SQLStore {
+	t.Helper()
+	dsn := os.Getenv("IOTUBE_TEST_MYSQL_DSN")
+	if dsn == "" {
+		t.Skip("IOTUBE_TEST_MYSQL_DSN is not set")
+	}
+	store := db.NewSQLStoreFactory().NewStore(db.Config{Driver: "mysql", URI: dsn})
+	require.NoError(t, store.Start(context.Background()))
+	t.Cleanup(func() {
+		require.NoError(t, store.Stop(context.Background()))
+	})
+	return store
+}
+
+func TestMigrateTransferPrimaryKeyMySQL(t *testing.T) {
+	store := mysqlIntegrationStore(t)
+	table := fmt.Sprintf("relayer_legacy_%d", time.Now().UnixNano())
+	witnessTable := table + "_witnesses"
+	quotedTable, err := mysqlIdentifier(table)
+	require.NoError(t, err)
+	quotedWitnessTable, err := mysqlIdentifier(witnessTable)
+	require.NoError(t, err)
+	_, err = store.DB().Exec(fmt.Sprintf(
+		"CREATE TABLE %s (`cashier` varchar(64) NOT NULL, `token` varchar(42) NOT NULL, `tidx` bigint NOT NULL, `id` varchar(66) NOT NULL, PRIMARY KEY (`cashier`,`token`,`tidx`), UNIQUE KEY `id_UNIQUE` (`id`)) ENGINE=InnoDB",
+		quotedTable,
+	))
+	require.NoError(t, err)
+	_, err = store.DB().Exec(fmt.Sprintf(
+		"CREATE TABLE %s (`transferId` varchar(66) NOT NULL, PRIMARY KEY (`transferId`), FOREIGN KEY (`transferId`) REFERENCES %s (`id`) ON DELETE CASCADE) ENGINE=InnoDB",
+		quotedWitnessTable,
+		quotedTable,
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, dropErr := store.DB().Exec("DROP TABLE IF EXISTS " + quotedWitnessTable)
+		require.NoError(t, dropErr)
+		_, dropErr = store.DB().Exec("DROP TABLE IF EXISTS " + quotedTable)
+		require.NoError(t, dropErr)
+	})
+
+	require.NoError(t, migrateTransferPrimaryKey(store, table))
+	require.NoError(t, migrateTransferPrimaryKey(store, table))
+	_, err = store.DB().Exec(
+		fmt.Sprintf("INSERT INTO %s (`cashier`,`token`,`tidx`,`id`) VALUES (?,?,?,?),(?,?,?,?)", quotedTable),
+		"cashier", "token", 1, "id-1",
+		"cashier", "token", 1, "id-2",
+	)
+	require.NoError(t, err)
+
+	var count int
+	require.NoError(t, store.DB().QueryRow("SELECT COUNT(*) FROM "+quotedTable).Scan(&count))
+	require.Equal(t, 2, count)
+}
+
+func TestTransfersWithWitnessQuorumMySQL(t *testing.T) {
+	store := mysqlIntegrationStore(t)
+	suffix := time.Now().UnixNano()
+	transferTable := fmt.Sprintf("relayer_transfers_%d", suffix)
+	witnessTable := fmt.Sprintf("relayer_witnesses_%d", suffix)
+	recorder := NewRecorder(store, nil, transferTable, witnessTable, "", "")
+	require.NoError(t, recorder.Start(context.Background()))
+	t.Cleanup(func() {
+		quotedWitness, quoteErr := mysqlIdentifier(witnessTable)
+		require.NoError(t, quoteErr)
+		quotedTransfer, quoteErr := mysqlIdentifier(transferTable)
+		require.NoError(t, quoteErr)
+		_, dropErr := store.DB().Exec("DROP TABLE IF EXISTS " + quotedWitness)
+		require.NoError(t, dropErr)
+		_, dropErr = store.DB().Exec("DROP TABLE IF EXISTS " + quotedTransfer)
+		require.NoError(t, dropErr)
+	})
+
+	validatorAddr := common.HexToAddress("0x9000000000000000000000000000000000000009")
+	cashierAddr := common.HexToAddress("0x1000000000000000000000000000000000000001")
+	proposal := func(recipient common.Address) *Transfer {
+		transfer := &Transfer{
+			cashier:     util.ETHAddressToAddress(cashierAddr),
+			token:       util.ETHAddressToAddress(common.HexToAddress("0x2000000000000000000000000000000000000002")),
+			index:       7,
+			sender:      util.ETHAddressToAddress(common.HexToAddress("0x3000000000000000000000000000000000000003")),
+			recipient:   util.ETHAddressToAddress(recipient),
+			amount:      big.NewInt(10),
+			fee:         big.NewInt(0),
+			timestamp:   time.Now(),
+			gasPrice:    big.NewInt(0),
+			txSender:    util.ETHAddressToAddress(common.HexToAddress("0x5000000000000000000000000000000000000005")),
+			blockHeight: 100,
+		}
+		transfer.GenID(validatorAddr)
+		return transfer
+	}
+	blockedProposal := proposal(common.HexToAddress("0x4000000000000000000000000000000000000004"))
+	readyProposal := proposal(common.HexToAddress("0x4100000000000000000000000000000000000004"))
+	activeWitnesses := []common.Address{
+		common.HexToAddress("0xa000000000000000000000000000000000000001"),
+		common.HexToAddress("0xa000000000000000000000000000000000000002"),
+		common.HexToAddress("0xa000000000000000000000000000000000000003"),
+		common.HexToAddress("0xa000000000000000000000000000000000000004"),
+	}
+	require.NoError(t, recorder.AddTransferAndWitness(
+		util.ETHAddressToAddress(validatorAddr),
+		blockedProposal,
+		&Witness{addr: activeWitnesses[0].Bytes(), signature: []byte{1}},
+		nil,
+		nil,
+	))
+	for i := 0; i < 3; i++ {
+		require.NoError(t, recorder.AddTransferAndWitness(
+			util.ETHAddressToAddress(validatorAddr),
+			readyProposal,
+			&Witness{addr: activeWitnesses[i].Bytes(), signature: []byte{byte(i + 1)}},
+			nil,
+			nil,
+		))
+	}
+
+	transfers, err := recorder.TransfersWithWitnessQuorum(
+		10,
+		activeWitnesses,
+		CashiersQueryOption([]string{util.ETHAddressToAddress(cashierAddr).String()}),
+	)
+	require.NoError(t, err)
+	require.Len(t, transfers, 1)
+	require.Equal(t, readyProposal.ID(), transfers[0].ID())
+}

--- a/witness-service/relayer/server.go
+++ b/witness-service/relayer/server.go
@@ -2,27 +2,94 @@ package relayer
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/ioTube/witness-service/grpc/services"
 )
 
-func startGRPCService(srv services.RelayServiceServer, grpcPort int) error {
+const maxRelayRequestBytes = 64 << 10
+
+var adminRPCMethods = map[string]struct{}{
+	services.RelayService_Reset_FullMethodName:       {},
+	services.RelayService_Retry_FullMethodName:       {},
+	services.RelayService_SubmitNewTX_FullMethodName: {},
+}
+
+var publicHTTPPaths = map[string]struct{}{
+	"/check":     {},
+	"/list":      {},
+	"/listnewtx": {},
+	"/lookup":    {},
+}
+
+func adminUnaryInterceptor(adminToken string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if _, protected := adminRPCMethods[info.FullMethod]; !protected {
+			return handler(ctx, req)
+		}
+		requestPeer, ok := peer.FromContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.PermissionDenied, "admin RPCs are local-only")
+		}
+		peerAddr, isTCP := requestPeer.Addr.(*net.TCPAddr)
+		if !isTCP || !peerAddr.IP.IsLoopback() {
+			return nil, status.Error(codes.PermissionDenied, "admin RPCs are local-only")
+		}
+		if adminToken == "" {
+			return nil, status.Error(codes.PermissionDenied, "admin RPCs are disabled")
+		}
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "missing admin authorization")
+		}
+		for _, value := range md.Get("authorization") {
+			if !strings.HasPrefix(value, "Bearer ") {
+				continue
+			}
+			provided := strings.TrimPrefix(value, "Bearer ")
+			if subtle.ConstantTimeCompare([]byte(provided), []byte(adminToken)) == 1 {
+				return handler(ctx, req)
+			}
+		}
+		return nil, status.Error(codes.Unauthenticated, "invalid admin authorization")
+	}
+}
+
+func publicRelayHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, allowed := publicHTTPPaths[r.URL.Path]; !allowed {
+			http.NotFound(w, r)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxRelayRequestBytes)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func startGRPCService(srv services.RelayServiceServer, grpcPort int, adminToken string) error {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", grpcPort))
 	if err != nil {
 		return err
 	}
 
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(
+		grpc.MaxRecvMsgSize(maxRelayRequestBytes),
+		grpc.UnaryInterceptor(adminUnaryInterceptor(adminToken)),
+	)
 	services.RegisterRelayServiceServer(grpcServer, srv)
-	reflection.Register(grpcServer)
 	return grpcServer.Serve(lis)
 }
 
@@ -35,16 +102,20 @@ func startGRPCProxyService(srv services.RelayServiceServer, grpcProxyPort int) e
 	}
 	port := fmt.Sprintf(":%d", grpcProxyPort)
 	gwServer := &http.Server{
-		Addr:    port,
-		Handler: gwmux,
+		Addr:              port,
+		Handler:           publicRelayHandler(gwmux),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 	return gwServer.ListenAndServe()
 }
 
-func StartServer(srv services.RelayServiceServer, grpcPort int, grpcProxyPort int) {
+func StartServer(srv services.RelayServiceServer, grpcPort int, grpcProxyPort int, adminToken string) {
 	if grpcPort > 0 {
 		go func() {
-			if e := startGRPCService(srv, grpcPort); e != nil {
+			if e := startGRPCService(srv, grpcPort, adminToken); e != nil {
 				log.Fatalf("failed to start grpc service: %v\n", e)
 			}
 		}()

--- a/witness-service/relayer/server_test.go
+++ b/witness-service/relayer/server_test.go
@@ -1,0 +1,104 @@
+package relayer
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"github.com/iotexproject/ioTube/witness-service/grpc/services"
+)
+
+func TestPublicRelayHandler(t *testing.T) {
+	tests := []struct {
+		path        string
+		wantStatus  int
+		wantHandled bool
+	}{
+		{path: "/list", wantStatus: http.StatusNoContent, wantHandled: true},
+		{path: "/lookup", wantStatus: http.StatusNoContent, wantHandled: true},
+		{path: "/submit", wantStatus: http.StatusNotFound},
+		{path: "/reset", wantStatus: http.StatusNotFound},
+		{path: "/stale_heights", wantStatus: http.StatusNotFound},
+	}
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			handled := false
+			handler := publicRelayHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				handled = true
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			request := httptest.NewRequest(http.MethodPost, test.path, nil)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			require.Equal(t, test.wantStatus, response.Code)
+			require.Equal(t, test.wantHandled, handled)
+		})
+	}
+}
+
+func TestAdminUnaryInterceptor(t *testing.T) {
+	const token = "test-admin-token"
+	interceptor := adminUnaryInterceptor(token)
+	info := &grpc.UnaryServerInfo{FullMethod: services.RelayService_Reset_FullMethodName}
+	handlerCalled := false
+	handler := func(context.Context, interface{}) (interface{}, error) {
+		handlerCalled = true
+		return "ok", nil
+	}
+
+	_, err := interceptor(context.Background(), nil, info, handler)
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+	require.False(t, handlerCalled)
+
+	remoteContext := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 1234},
+	})
+	remoteContext = metadata.NewIncomingContext(remoteContext, metadata.Pairs("authorization", "Bearer "+token))
+	_, err = interceptor(remoteContext, nil, info, handler)
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+	require.False(t, handlerCalled)
+
+	localContext := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234},
+	})
+	_, err = interceptor(localContext, nil, info, handler)
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+	require.False(t, handlerCalled)
+
+	localContext = metadata.NewIncomingContext(localContext, metadata.Pairs("authorization", "Bearer "+token))
+	response, err := interceptor(localContext, nil, info, handler)
+	require.NoError(t, err)
+	require.Equal(t, "ok", response)
+	require.True(t, handlerCalled)
+}
+
+func TestAdminUnaryInterceptorAllowsNonAdminRPC(t *testing.T) {
+	interceptor := adminUnaryInterceptor("")
+	info := &grpc.UnaryServerInfo{FullMethod: services.RelayService_Submit_FullMethodName}
+	response, err := interceptor(context.Background(), nil, info, func(context.Context, interface{}) (interface{}, error) {
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ok", response)
+}
+
+func TestAdminUnaryInterceptorDisablesAdminRPCWithoutToken(t *testing.T) {
+	interceptor := adminUnaryInterceptor("")
+	info := &grpc.UnaryServerInfo{FullMethod: services.RelayService_Reset_FullMethodName}
+	localContext := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234},
+	})
+	_, err := interceptor(localContext, nil, info, func(context.Context, interface{}) (interface{}, error) {
+		return "unexpected", nil
+	})
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+}

--- a/witness-service/relayer/service.go
+++ b/witness-service/relayer/service.go
@@ -128,7 +128,7 @@ func (s *Service) submit(w *types.Witness) ([]byte, error) {
 	if len(w.Address) != common.AddressLength {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid witness address length %d", len(w.Address))
 	}
-	if len(w.Signature) != crypto.SignatureLength {
+	if len(w.Signature) != 0 && len(w.Signature) != crypto.SignatureLength {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid witness signature length %d", len(w.Signature))
 	}
 	transfer, err := UnmarshalTransferProto(w.Transfer, s.destAddrDecoder)
@@ -144,6 +144,11 @@ func (s *Service) submit(w *types.Witness) ([]byte, error) {
 		return nil, errors.Errorf("no validator is found for %s", cashier.String())
 	}
 	transfer.GenID(validator.Address())
+	if len(w.Signature) == 0 {
+		// Legacy witnesses announce unconfirmed transfers without a signature. Ack
+		// those announcements without persisting any untrusted transfer or witness.
+		return transfer.ID().Bytes(), nil
+	}
 	witnessAddr := common.BytesToAddress(w.Address)
 	if err := validateSignature(transfer.id.Bytes(), witnessAddr, w.Signature); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/witness-service/relayer/service.go
+++ b/witness-service/relayer/service.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/iotexproject/ioTube/witness-service/dispatcher"
@@ -120,6 +122,15 @@ func (s *Service) submit(w *types.Witness) ([]byte, error) {
 	if s.validators == nil {
 		return nil, errors.New("cannot accept new submission")
 	}
+	if w == nil || w.Transfer == nil {
+		return nil, status.Error(codes.InvalidArgument, "transfer is required")
+	}
+	if len(w.Address) != common.AddressLength {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid witness address length %d", len(w.Address))
+	}
+	if len(w.Signature) != crypto.SignatureLength {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid witness signature length %d", len(w.Signature))
+	}
 	transfer, err := UnmarshalTransferProto(w.Transfer, s.destAddrDecoder)
 	if err != nil {
 		return nil, err
@@ -133,22 +144,20 @@ func (s *Service) submit(w *types.Witness) ([]byte, error) {
 		return nil, errors.Errorf("no validator is found for %s", cashier.String())
 	}
 	transfer.GenID(validator.Address())
-	var witness *Witness
-	if len(w.Signature) != 0 {
-		if err := validateSignature(transfer.id.Bytes(), common.BytesToAddress(w.Address), w.Signature); err != nil {
-			return nil, err
-		}
-		// Reject signatures from addresses that are not registered on-chain witnesses,
-		// so forged/junk submissions never enter the DB. Fail open when the witness
-		// set has not been loaded from chain yet — the on-chain validator is still the
-		// ultimate gate for settlement.
-		if member, loaded := validator.IsActiveWitness(common.BytesToAddress(w.Address)); loaded && !member {
-			return nil, errors.Errorf("rejecting submission from non-witness %s", common.BytesToAddress(w.Address).Hex())
-		}
-		witness, err = NewWitness(w.Address, w.Signature)
-		if err != nil {
-			return nil, err
-		}
+	witnessAddr := common.BytesToAddress(w.Address)
+	if err := validateSignature(transfer.id.Bytes(), witnessAddr, w.Signature); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	member, loaded := validator.IsActiveWitness(witnessAddr)
+	if !loaded {
+		return nil, status.Error(codes.Unavailable, "active witness set is unavailable")
+	}
+	if !member {
+		return nil, status.Errorf(codes.PermissionDenied, "submission signer %s is not an active witness", witnessAddr.Hex())
+	}
+	witness, err := NewWitness(w.Address, w.Signature)
+	if err != nil {
+		return nil, err
 	}
 	var fboToken, fboRecipient *common.Address
 	unwrapper, ok := s.unwrappers[transfer.recipient.String()]
@@ -620,11 +629,13 @@ func (s *Service) confirmTransfer(transfer *Transfer, validator TransferValidato
 func (s *Service) submitTransfers() error {
 	excludedAddr, _ := util.NewETHAddressDecoder().DecodeString("0x6fb3e0a217407efff7ca062d46c26e5d60a14d69")
 	for cashier, validator := range s.validators {
-		newTransfers, err := s.recorder.Transfers(
-			0,
+		activeWitnesses, err := validator.ActiveWitnesses()
+		if err != nil {
+			return errors.Wrapf(err, "failed to load active witnesses for %s", cashier)
+		}
+		newTransfers, err := s.recorder.TransfersWithWitnessQuorum(
 			uint8(validator.Size()+1),
-			AESC,
-			StatusQueryOption(WaitingForWitnesses),
+			activeWitnesses,
 			ExcludeTokenQueryOption(excludedAddr),
 			CashiersQueryOption([]string{cashier}),
 		)
@@ -632,11 +643,9 @@ func (s *Service) submitTransfers() error {
 			return err
 		}
 		if len(newTransfers) == 0 {
-			newTransfers, err = s.recorder.Transfers(
-				0,
+			newTransfers, err = s.recorder.TransfersWithWitnessQuorum(
 				uint8(validator.Size()),
-				AESC,
-				StatusQueryOption(WaitingForWitnesses),
+				activeWitnesses,
 				CashiersQueryOption([]string{cashier}),
 			)
 			if err != nil {

--- a/witness-service/relayer/service_test.go
+++ b/witness-service/relayer/service_test.go
@@ -1,0 +1,118 @@
+package relayer
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/iotexproject/ioTube/witness-service/grpc/types"
+	"github.com/iotexproject/ioTube/witness-service/util"
+)
+
+type submissionTestValidator struct {
+	address common.Address
+	member  bool
+	loaded  bool
+}
+
+func (v *submissionTestValidator) Size() int { return 1 }
+
+func (v *submissionTestValidator) Address() common.Address { return v.address }
+
+func (v *submissionTestValidator) Check(*Transfer) (StatusOnChainType, error) {
+	return StatusOnChainUnknown, nil
+}
+
+func (v *submissionTestValidator) IsActiveWitness(common.Address) (bool, bool) {
+	return v.member, v.loaded
+}
+
+func (v *submissionTestValidator) ActiveWitnesses() ([]common.Address, error) { return nil, nil }
+
+func (v *submissionTestValidator) Submit(*Transfer, []*Witness) (common.Hash, common.Address, uint64, *big.Int, error) {
+	return common.Hash{}, common.Address{}, 0, nil, nil
+}
+
+func (v *submissionTestValidator) SpeedUp(*Transfer, []*Witness) (common.Hash, common.Address, uint64, *big.Int, error) {
+	return common.Hash{}, common.Address{}, 0, nil, nil
+}
+
+func signedSubmission(t *testing.T, validatorAddr common.Address) *types.Witness {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	cashier := common.HexToAddress("0x1000000000000000000000000000000000000001")
+	transferProto := &types.Transfer{
+		Cashier:     cashier.Bytes(),
+		Token:       common.HexToAddress("0x2000000000000000000000000000000000000002").Bytes(),
+		Index:       7,
+		Sender:      common.HexToAddress("0x3000000000000000000000000000000000000003").Bytes(),
+		Recipient:   common.HexToAddress("0x4000000000000000000000000000000000000004").Bytes(),
+		Amount:      "10",
+		Fee:         "0",
+		Timestamp:   timestamppb.Now(),
+		GasPrice:    "0",
+		TxSender:    common.HexToAddress("0x5000000000000000000000000000000000000005").Bytes(),
+		BlockHeight: 100,
+	}
+	transfer, err := UnmarshalTransferProto(transferProto, util.NewETHAddressDecoder())
+	require.NoError(t, err)
+	transfer.GenID(validatorAddr)
+	signature, err := crypto.Sign(transfer.ID().Bytes(), key)
+	require.NoError(t, err)
+	return &types.Witness{
+		Transfer:  transferProto,
+		Address:   crypto.PubkeyToAddress(key.PublicKey).Bytes(),
+		Signature: signature,
+	}
+}
+
+func submissionTestService(w *types.Witness, validator *submissionTestValidator) *Service {
+	cashier, _ := util.ParseAddressBytes(w.Transfer.Cashier)
+	return &Service{
+		validators:      map[string]TransferValidator{cashier.String(): validator},
+		unwrappers:      map[string]map[string]common.Address{},
+		destAddrDecoder: util.NewETHAddressDecoder(),
+	}
+}
+
+func TestSubmitRejectsUnsignedTransfer(t *testing.T) {
+	validator := &submissionTestValidator{address: common.HexToAddress("0x6000000000000000000000000000000000000006"), member: true, loaded: true}
+	witness := signedSubmission(t, validator.address)
+	witness.Signature = nil
+	_, err := submissionTestService(witness, validator).submit(witness)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestSubmitFailsClosedWithoutWitnessSet(t *testing.T) {
+	validator := &submissionTestValidator{address: common.HexToAddress("0x6000000000000000000000000000000000000006"), member: true, loaded: false}
+	witness := signedSubmission(t, validator.address)
+	_, err := submissionTestService(witness, validator).submit(witness)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+func TestSubmitRejectsInactiveWitness(t *testing.T) {
+	validator := &submissionTestValidator{address: common.HexToAddress("0x6000000000000000000000000000000000000006"), member: false, loaded: true}
+	witness := signedSubmission(t, validator.address)
+	_, err := submissionTestService(witness, validator).submit(witness)
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func TestIsActiveWitnessFailsClosedWithStaleCache(t *testing.T) {
+	witness := common.HexToAddress("0xa000000000000000000000000000000000000001")
+	validator := &transferValidatorOnEthereum{
+		witnesses:                 map[string]bool{witness.Hex(): true},
+		lastWitnessRefresh:        time.Now().Add(-2 * witnessRefreshCooldown),
+		lastWitnessRefreshAttempt: time.Now(),
+	}
+	member, loaded := validator.IsActiveWitness(witness)
+	require.False(t, member)
+	require.False(t, loaded)
+}

--- a/witness-service/relayer/service_test.go
+++ b/witness-service/relayer/service_test.go
@@ -1,12 +1,17 @@
 package relayer
 
 import (
+	"context"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -83,10 +88,24 @@ func submissionTestService(w *types.Witness, validator *submissionTestValidator)
 	}
 }
 
-func TestSubmitRejectsUnsignedTransfer(t *testing.T) {
-	validator := &submissionTestValidator{address: common.HexToAddress("0x6000000000000000000000000000000000000006"), member: true, loaded: true}
+func TestSubmitAcknowledgesLegacyUnsignedTransferWithoutPersistence(t *testing.T) {
+	validator := &submissionTestValidator{address: common.HexToAddress("0x6000000000000000000000000000000000000006")}
 	witness := signedSubmission(t, validator.address)
 	witness.Signature = nil
+	response, err := submissionTestService(witness, validator).Submit(context.Background(), witness)
+	require.NoError(t, err)
+	require.True(t, response.Success)
+
+	transfer, err := UnmarshalTransferProto(witness.Transfer, util.NewETHAddressDecoder())
+	require.NoError(t, err)
+	transfer.GenID(validator.address)
+	require.Equal(t, transfer.ID().Bytes(), response.Id)
+}
+
+func TestSubmitRejectsMalformedSignature(t *testing.T) {
+	validator := &submissionTestValidator{address: common.HexToAddress("0x6000000000000000000000000000000000000006"), member: true, loaded: true}
+	witness := signedSubmission(t, validator.address)
+	witness.Signature = []byte{1}
 	_, err := submissionTestService(witness, validator).submit(witness)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
@@ -115,4 +134,65 @@ func TestIsActiveWitnessFailsClosedWithStaleCache(t *testing.T) {
 	member, loaded := validator.IsActiveWitness(witness)
 	require.False(t, member)
 	require.False(t, loaded)
+}
+
+func TestActiveWitnessesFailsClosedWithStaleCache(t *testing.T) {
+	witness := common.HexToAddress("0xa000000000000000000000000000000000000001")
+	validator := &transferValidatorOnEthereum{
+		witnesses:                 map[string]bool{witness.Hex(): true},
+		lastWitnessRefresh:        time.Now().Add(-2 * witnessRefreshCooldown),
+		lastWitnessRefreshAttempt: time.Now(),
+	}
+	witnesses, err := validator.ActiveWitnesses()
+	require.Error(t, err)
+	require.Nil(t, witnesses)
+}
+
+func TestWitnessRefreshDoesNotHoldStateLockDuringRPC(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var requestOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requestOnce.Do(func() { close(requestStarted) })
+		<-releaseRequest
+	}))
+	defer server.Close()
+	defer close(releaseRequest)
+
+	client, err := ethclient.Dial(server.URL)
+	require.NoError(t, err)
+	defer client.Close()
+	validator := &transferValidatorOnEthereum{client: client}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	refreshDone := make(chan error, 1)
+	go func() {
+		refreshDone <- validator.refreshWithContext(ctx)
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("witness refresh did not start its RPC")
+	}
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		validator.mu.Lock()
+		validator.mu.Unlock()
+		close(lockAcquired)
+	}()
+	select {
+	case <-lockAcquired:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("witness refresh held the state lock during RPC")
+	}
+
+	cancel()
+	select {
+	case err := <-refreshDone:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("witness refresh ignored context cancellation")
+	}
 }

--- a/witness-service/relayer/transfervalidatoronethereum.go
+++ b/witness-service/relayer/transfervalidatoronethereum.go
@@ -11,6 +11,7 @@ import (
 	"crypto/ecdsa"
 	"log"
 	"math/big"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -51,8 +52,7 @@ type (
 		validator           validatorContract
 		witnessListContract *contract.AddressListCaller
 		witnesses           map[string]bool
-		// lastWitnessRefresh is the time of the last *successful* on-chain load;
-		// drives the fail-open "genuinely not a member" decision in IsActiveWitness.
+		// lastWitnessRefresh is the time of the last successful on-chain load.
 		lastWitnessRefresh time.Time
 		// lastWitnessRefreshAttempt is the time of the last refresh *attempt*
 		// (success or failure); rate-limits the on-miss refresh so a stream of junk
@@ -357,9 +357,8 @@ const witnessRefreshCooldown = 30 * time.Second
 // from chain once (rate-limited to once per witnessRefreshCooldown, shared with the
 // refresh done during submission) before trusting either verdict, so both additions
 // and removals to the on-chain set are reflected. If the refresh fails or is rate-
-// limited away, a non-membership result returns loaded==false; callers should treat
-// loaded==false as "unknown" and fail open (the on-chain validator is the ultimate
-// gate). Safe for concurrent use.
+// limited away, loaded is false and callers must reject the submission. Safe for
+// concurrent use.
 func (tv *transferValidatorOnEthereum) IsActiveWitness(addr common.Address) (isMember bool, loaded bool) {
 	hexAddr := addr.Hex()
 	tv.mu.RLock()
@@ -384,12 +383,35 @@ func (tv *transferValidatorOnEthereum) IsActiveWitness(addr common.Address) (isM
 	fresh = len(tv.witnesses) > 0 && !tv.lastWitnessRefresh.IsZero() &&
 		time.Since(tv.lastWitnessRefresh) <= witnessRefreshCooldown
 	tv.mu.Unlock()
-	if member {
-		return true, true
+	if !fresh {
+		return false, false
 	}
-	// Only a fresh, successful load makes a non-membership verdict authoritative;
-	// otherwise report unknown so the caller falls back to the on-chain gate.
-	return false, fresh
+	return member, true
+}
+
+// ActiveWitnesses returns a fresh snapshot of the on-chain witness set. Settlement
+// scheduling uses this list so rows without a live quorum never enter the queue.
+func (tv *transferValidatorOnEthereum) ActiveWitnesses() ([]common.Address, error) {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+
+	fresh := len(tv.witnesses) > 0 && !tv.lastWitnessRefresh.IsZero() &&
+		time.Since(tv.lastWitnessRefresh) <= witnessRefreshCooldown
+	if !fresh {
+		if err := tv.refresh(); err != nil {
+			return nil, errors.Wrap(err, "failed to refresh active witness set")
+		}
+	}
+	addresses := make([]string, 0, len(tv.witnesses))
+	for addr := range tv.witnesses {
+		addresses = append(addresses, addr)
+	}
+	sort.Strings(addresses)
+	witnesses := make([]common.Address, 0, len(addresses))
+	for _, addr := range addresses {
+		witnesses = append(witnesses, common.HexToAddress(addr))
+	}
+	return witnesses, nil
 }
 
 // Check returns true if a transfer has been settled

--- a/witness-service/relayer/transfervalidatoronethereum.go
+++ b/witness-service/relayer/transfervalidatoronethereum.go
@@ -36,6 +36,7 @@ type (
 	// transferValidatorOnEthereum defines the transfer validator
 	transferValidatorOnEthereum struct {
 		mu                 sync.RWMutex
+		witnessRefreshMu   sync.Mutex
 		confirmBlockNumber uint16
 		defaultGasPrice    *big.Int
 		gasPriceLimit      *big.Int
@@ -278,7 +279,9 @@ func NewTransferValidatorOnEthereum(
 		validator: validator,
 	}
 
-	callOpts, err := tv.callOpts()
+	ctx, cancel := context.WithTimeout(context.Background(), witnessRefreshTimeout)
+	defer cancel()
+	callOpts, err := tv.callOpts(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -306,11 +309,33 @@ func (tv *transferValidatorOnEthereum) Address() common.Address {
 }
 
 func (tv *transferValidatorOnEthereum) refresh() error {
-	// Stamp the attempt up front (caller holds tv.mu) so the on-miss rate limit in
-	// IsActiveWitness backs off even when the RPC below errors and we never reach
-	// the success stamp.
-	tv.lastWitnessRefreshAttempt = time.Now()
-	callOpts, err := tv.callOpts()
+	ctx, cancel := context.WithTimeout(context.Background(), witnessRefreshTimeout)
+	defer cancel()
+	return tv.refreshWithContext(ctx)
+}
+
+func (tv *transferValidatorOnEthereum) refreshWithContext(ctx context.Context) error {
+	tv.witnessRefreshMu.Lock()
+	defer tv.witnessRefreshMu.Unlock()
+
+	now := time.Now()
+	tv.mu.RLock()
+	fresh := len(tv.witnesses) > 0 && !tv.lastWitnessRefresh.IsZero() &&
+		now.Sub(tv.lastWitnessRefresh) <= witnessRefreshCooldown
+	recentAttempt := !tv.lastWitnessRefreshAttempt.IsZero() &&
+		now.Sub(tv.lastWitnessRefreshAttempt) <= witnessRefreshCooldown
+	tv.mu.RUnlock()
+	if fresh || recentAttempt {
+		return nil
+	}
+
+	// Record the attempt before issuing RPCs, but never hold the state lock while
+	// waiting on the chain. This rate-limits failures without blocking cache reads.
+	tv.mu.Lock()
+	tv.lastWitnessRefreshAttempt = now
+	tv.mu.Unlock()
+
+	callOpts, err := tv.callOpts(ctx)
 	if err != nil {
 		return err
 	}
@@ -337,8 +362,10 @@ func (tv *transferValidatorOnEthereum) refresh() error {
 		activeWitnesses[w.Hex()] = true
 	}
 
+	tv.mu.Lock()
 	tv.witnesses = activeWitnesses
 	tv.lastWitnessRefresh = time.Now()
+	tv.mu.Unlock()
 	return nil
 }
 
@@ -350,7 +377,10 @@ func (tv *transferValidatorOnEthereum) isActiveWitness(witness common.Address) b
 
 // witnessRefreshCooldown bounds how often IsActiveWitness re-queries the on-chain
 // witness set on a miss, so junk addresses can't spam refresh RPCs.
-const witnessRefreshCooldown = 30 * time.Second
+const (
+	witnessRefreshCooldown = 30 * time.Second
+	witnessRefreshTimeout  = 15 * time.Second
+)
 
 // IsActiveWitness reports whether addr is in the on-chain registered witness set,
 // and whether that set is currently loaded. When the cached set is stale it refreshes
@@ -372,17 +402,14 @@ func (tv *transferValidatorOnEthereum) IsActiveWitness(addr common.Address) (isM
 	}
 	// Stale or never loaded: refresh once (rate-limited by the last refresh attempt,
 	// not the last success, so a failing RPC still backs off) and re-check.
-	tv.mu.Lock()
-	if tv.lastWitnessRefreshAttempt.IsZero() ||
-		time.Since(tv.lastWitnessRefreshAttempt) > witnessRefreshCooldown {
-		if err := tv.refresh(); err != nil {
-			log.Printf("failed to refresh witness set: %v\n", err)
-		}
+	if err := tv.refresh(); err != nil {
+		log.Printf("failed to refresh witness set: %v\n", err)
 	}
+	tv.mu.RLock()
 	_, member = tv.witnesses[hexAddr]
 	fresh = len(tv.witnesses) > 0 && !tv.lastWitnessRefresh.IsZero() &&
 		time.Since(tv.lastWitnessRefresh) <= witnessRefreshCooldown
-	tv.mu.Unlock()
+	tv.mu.RUnlock()
 	if !fresh {
 		return false, false
 	}
@@ -392,15 +419,21 @@ func (tv *transferValidatorOnEthereum) IsActiveWitness(addr common.Address) (isM
 // ActiveWitnesses returns a fresh snapshot of the on-chain witness set. Settlement
 // scheduling uses this list so rows without a live quorum never enter the queue.
 func (tv *transferValidatorOnEthereum) ActiveWitnesses() ([]common.Address, error) {
-	tv.mu.Lock()
-	defer tv.mu.Unlock()
-
+	tv.mu.RLock()
 	fresh := len(tv.witnesses) > 0 && !tv.lastWitnessRefresh.IsZero() &&
 		time.Since(tv.lastWitnessRefresh) <= witnessRefreshCooldown
+	tv.mu.RUnlock()
 	if !fresh {
 		if err := tv.refresh(); err != nil {
 			return nil, errors.Wrap(err, "failed to refresh active witness set")
 		}
+	}
+	tv.mu.RLock()
+	defer tv.mu.RUnlock()
+	fresh = len(tv.witnesses) > 0 && !tv.lastWitnessRefresh.IsZero() &&
+		time.Since(tv.lastWitnessRefresh) <= witnessRefreshCooldown
+	if !fresh {
+		return nil, errors.New("active witness set is unavailable")
 	}
 	addresses := make([]string, 0, len(tv.witnesses))
 	for addr := range tv.witnesses {
@@ -489,9 +522,6 @@ func (tv *transferValidatorOnEthereum) privateKeyOfRelayer(relayer common.Addres
 }
 
 func (tv *transferValidatorOnEthereum) submit(transfer *Transfer, witnesses []*Witness, isSpeedUp bool) (common.Hash, common.Address, uint64, *big.Int, error) {
-	if err := tv.refresh(); err != nil {
-		return common.Hash{}, common.Address{}, 0, nil, errors.Wrap(errNoncritical, err.Error())
-	}
 	signatures := []byte{}
 	numOfValidSignatures := 0
 	for _, witness := range witnesses {
@@ -552,6 +582,9 @@ func (tv *transferValidatorOnEthereum) submit(transfer *Transfer, witnesses []*W
 
 // Submit submits validation for a transfer
 func (tv *transferValidatorOnEthereum) Submit(transfer *Transfer, witnesses []*Witness) (common.Hash, common.Address, uint64, *big.Int, error) {
+	if _, err := tv.ActiveWitnesses(); err != nil {
+		return common.Hash{}, common.Address{}, 0, nil, errors.Wrap(errNoncritical, err.Error())
+	}
 	tv.mu.Lock()
 	defer tv.mu.Unlock()
 
@@ -560,6 +593,9 @@ func (tv *transferValidatorOnEthereum) Submit(transfer *Transfer, witnesses []*W
 
 // SpeedUp creases the transaction gas price
 func (tv *transferValidatorOnEthereum) SpeedUp(transfer *Transfer, witnesses []*Witness) (common.Hash, common.Address, uint64, *big.Int, error) {
+	if _, err := tv.ActiveWitnesses(); err != nil {
+		return common.Hash{}, common.Address{}, 0, nil, errors.Wrap(errNoncritical, err.Error())
+	}
 	tv.mu.Lock()
 	defer tv.mu.Unlock()
 	if tv.gasPriceGap == nil || tv.gasPriceGap.Cmp(big.NewInt(0)) < 0 {
@@ -612,8 +648,8 @@ func (tv *transferValidatorOnEthereum) transactionOpts(privateKey *ecdsa.Private
 	return opts, nil
 }
 
-func (tv *transferValidatorOnEthereum) callOpts() (*bind.CallOpts, error) {
-	tipBlockHeader, err := tv.client.HeaderByNumber(context.Background(), nil)
+func (tv *transferValidatorOnEthereum) callOpts(ctx context.Context) (*bind.CallOpts, error) {
+	tipBlockHeader, err := tv.client.HeaderByNumber(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -622,5 +658,5 @@ func (tv *transferValidatorOnEthereum) callOpts() (*bind.CallOpts, error) {
 		return nil, errors.Errorf("Ethereum height %d is smaller than confirm height %d", tipBlockHeader.Number, tv.confirmBlockNumber)
 	}
 
-	return &bind.CallOpts{BlockNumber: blockNumber}, nil
+	return &bind.CallOpts{Context: ctx, BlockNumber: blockNumber}, nil
 }

--- a/witness-service/relayer/types.go
+++ b/witness-service/relayer/types.go
@@ -76,6 +76,8 @@ type (
 		// IsActiveWitness reports whether addr is a registered on-chain witness,
 		// and whether the witness set has been loaded from chain yet.
 		IsActiveWitness(addr common.Address) (isMember bool, loaded bool)
+		// ActiveWitnesses returns the current on-chain active witness set.
+		ActiveWitnesses() ([]common.Address, error)
 		// Submit submits validation for a transfer
 		Submit(transfer *Transfer, witnesses []*Witness) (common.Hash, common.Address, uint64, *big.Int, error)
 		// SpeedUp resubmits validation with higher gas price
@@ -253,12 +255,12 @@ func DecodeSourceAddrBytes(bytes []byte) (util.Address, error) {
 
 // NewWitness creates a new witness struct
 func NewWitness(witnessBytes []byte, signature []byte) (*Witness, error) {
-	clone := make([]byte, len(signature))
-	copy(clone, signature)
+	addrClone := append([]byte(nil), witnessBytes...)
+	signatureClone := append([]byte(nil), signature...)
 
 	return &Witness{
-		addr:      witnessBytes,
-		signature: signature,
+		addr:      addrClone,
+		signature: signatureClone,
 	}, nil
 }
 

--- a/witness-service/witness/recorder.go
+++ b/witness-service/witness/recorder.go
@@ -457,7 +457,7 @@ func (recorder *Recorder) TransfersToSettle(cashier string) ([]AbstractTransfer,
 
 // TransfersToSubmit returns the list of transfers to submit
 func (recorder *Recorder) TransfersToSubmit(cashier string) ([]AbstractTransfer, error) {
-	return recorder.transfers(cashier, TransferNew, TransferReady)
+	return recorder.transfers(cashier, TransferReady)
 }
 
 func (recorder *Recorder) transfers(cashier string, status ...TransferStatus) ([]AbstractTransfer, error) {

--- a/witness-service/witness/tokencashierbase.go
+++ b/witness-service/witness/tokencashierbase.go
@@ -371,19 +371,10 @@ func (tc *tokenCashierBase) SubmitTransfers() error {
 		if signature == nil {
 			continue
 		}
-		var witness *types.Witness
-		if transfer.Status() == TransferReady {
-			witness = &types.Witness{
-				Transfer:  transfer.ToTypesTransfer(),
-				Address:   pubkey,
-				Signature: signature,
-			}
-		} else {
-			witness = &types.Witness{
-				Transfer:  transfer.ToTypesTransfer(),
-				Address:   pubkey,
-				Signature: []byte{},
-			}
+		witness := &types.Witness{
+			Transfer:  transfer.ToTypesTransfer(),
+			Address:   pubkey,
+			Signature: signature,
 		}
 		response, err := relayer.Submit(context.Background(), witness)
 		if err != nil {
@@ -393,14 +384,8 @@ func (tc *tokenCashierBase) SubmitTransfers() error {
 			log.Printf("something went wrong when submitting transfer (%s, %s, %s) for %s\n", transfer.Cashier(), transfer.Token(), transfer.Index().String(), id)
 			continue
 		}
-		if transfer.Status() == TransferReady {
-			if err := tc.recorder.ConfirmTransfer(transfer); err != nil {
-				return err
-			}
-		} else {
-			if err := tc.recorder.MarkTransferAsPending(transfer); err != nil {
-				return err
-			}
+		if err := tc.recorder.ConfirmTransfer(transfer); err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Persist only valid signed submissions from active witnesses, while acknowledging legacy unsigned pre-announcements without storing them so witness and relayer binaries can be upgraded independently.
- Bound active-witness refresh RPCs to 15 seconds and perform them outside the validator state lock.
- Expose only read methods through the HTTP gateway and protect administrative gRPC methods with loopback and bearer-token checks.
- Key transfer proposals by the full signed transfer ID and schedule settlement only after signatures exceed two thirds of the current active witness set.
- Stop updated witnesses from sending provisional unsigned transfers.
- Enable finalized-minus-50 BSC confirmation tracking through the merged ioTube configs revision.
- Publish commit-SHA witness image tags for deterministic rollout pinning.

Config dependency: https://github.com/iotubeproject/iotube-configs/pull/13

## Database migration

- Relayer startup migrates the legacy `(cashier, token, tidx)` primary key to `id` while retaining the route index.
- Existing transfer IDs must remain unique; deployments should back up the database before rollout.
- The migration is idempotent and rechecks the schema if concurrent relayers race on the `ALTER TABLE` operation.

## Validation

- `go test ./...`
- `go test -race ./relayer ./cmd/witness`
- `go vet ./...`
- `git diff --check`
- MySQL migration and quorum integration coverage was added; those tests skip unless `IOTUBE_TEST_MYSQL_DSN` is configured, and no local MySQL runtime was available.
